### PR TITLE
fix(kafka_protocol_adaptor): correct RDKAFKA_INC for apt-installed librdkafka-dev

### DIFF
--- a/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile
+++ b/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile
@@ -34,7 +34,7 @@ LIBS:= $(shell pkg-config --libs $(PKGS))
 LDFLAGS:= -shared
 
 DS_INC:= ../../../../includes
-RDKAFKA_INC:=/usr/local/include/librdkafka
+RDKAFKA_INC:=/usr/include/librdkafka
 
 INC_PATHS:= -I $(DS_INC) -I $(RDKAFKA_INC) -I/opt/tritonclient/include
 CFLAGS+= $(INC_PATHS)


### PR DESCRIPTION
## Summary

`sudo make` inside `src/utils/nvds_msgapi/kafka_protocol_adaptor/` failed with:

\`\`\`
kafka_client.h:19:10: fatal error: rdkafka.h: No such file or directory
   19 | #include "rdkafka.h"
\`\`\`

The adaptor's `Makefile` hard-coded `RDKAFKA_INC=/usr/local/include/librdkafka`, but the adaptor's README directs users to `apt install librdkafka-dev`, which places the header at `/usr/include/librdkafka/`. Reverted `RDKAFKA_INC` to `/usr/include/librdkafka` — matches the public DS 9.0 release Makefile that this tree was originally derived from.

## Root cause

The line was a divergence from the public DS 9.0 source that snuck in during initial mono-repo import; it travelled here when the mono-repo's `src/` tree was migrated to this GitHub repo in PR #2. SQA flagged it while trying the manual `sudo make` flow documented in the adaptor README.

## Validation

- Same one-line change already validated on the internal mono-repo (GitLab MR !92, commit `f4ad051`): `sudo make NVDS_VERSION=9.0` produces `libnvds_kafka_proto.so` cleanly with `librdkafka-dev 2.3.0-1build2` + `libjansson-dev 2.14-2build2` from Ubuntu noble.
- Diff is byte-identical between the two repos (Makefiles match line-for-line apart from this), so no separate validation re-run on the GitHub clone is needed.

## Follow-ups (not in this PR)

- `NVDS_VERSION` has no default in the kafka Makefile, so direct `sudo make` (without `NVDS_VERSION=9.0`) expands the install path to `/opt/nvidia/deepstream/deepstream-/lib/`. Either default `NVDS_VERSION ?= 9.0` in the Makefile or note it in the adaptor README.
- `build.sh` msgapi loop silently ignores failures (`make ... 2>/dev/null || true`) — should be tightened so future adaptor regressions surface.