### PR TITLE
docs: fill OSS README + add src/README, relocate build and print_env

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,6 +1,6 @@
 # DeepStream Coding Agent
 
-A project showcasing how to leverage **AI coding assistants** (Cursor, Claude Code, etc.) for accelerated [NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) application development using a curated agentic skill and structured prompts.
+These skills showcase how to leverage **AI coding assistants** (Cursor, Claude Code, etc.) for accelerated [NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) application development using curated agentic skills and structured prompts.
 
 > **Disclaimer:** Code generated with AI coding assistants is intended as a development starting point. All generated code must undergo your full software development lifecycle (SDLC) — including code review, testing, and security validation — before production use.
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -30,20 +30,6 @@ The following are required on the target execution environment:
 
 ---
 
-## Project Structure
-
-```
-deepstream/                                 # repo root
-├── .agents/
-│   └── skills/                             # Agentic skills for guided DeepStream development
-│       ├── README.md                       # This file
-│       ├── deepstream-dev/                 # DeepStream development skill with condensed references
-│       └── deepstream-import-vision-model/ # Autonomous vision-model onboarding & benchmarking pipeline skill
-└── example_prompts/                        # Pre-built prompts for code generation
-```
-
----
-
 ## Purpose
 
 This project provides the tooling and reference material needed to:
@@ -396,25 +382,3 @@ Create the FastAPI server with all endpoints shown in @rtvi_vlm_openapi_spec.png
   </picture>
 </a>
 
----
-
-## Additional Resources
-
-- [NVIDIA DeepStream SDK Developer Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/)
-- [DeepStream Python Apps (GitHub)](https://github.com/NVIDIA-AI-IOT/deepstream_python_apps)
-- [GStreamer Documentation](https://gstreamer.freedesktop.org/documentation/)
-- [NVIDIA NGC DeepStream Container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream)
-
----
-
-## Contributing
-
-This project is currently not accepting contributions.
-
----
-
-## License
-
-This project is licensed under [Apache-2.0](../../LICENSE).
-
-SPDX-License-Identifier: Apache-2.0

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ A clear and concise description of what you expected to happen.
  - Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
  - Method of DeepStream install: [conda, Docker, pip, or from source]
    - If method of install is [Docker], provide `docker pull` & `docker run` commands used
- - Run `print_env.sh` from the project root and paste the results here
+ - Run `scripts/print_env.sh` from the project root and paste the results here
  
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -71,7 +71,7 @@ body:
     id: env-printout
     attributes:
       label: Full env printout
-      description: Please run and paste the output of the `print_env.sh` script here, to gather any other relevant environment details
+      description: Please run and paste the output of the `scripts/print_env.sh` script here, to gather any other relevant environment details
       render: shell
 
   - type: textarea

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 NVIDIA Corporation
+   Copyright 2026 NVIDIA Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ DeepStream/
 │   └── skills/                              # product-local AI agent skills
 │       ├── deepstream-dev/                  # general DS development skill
 │       └── deepstream-import-vision-model/  # autonomous vision-model onboarding skill
+├── .claude/                                 # Claude Code project-local config (settings, commands)
 ├── .github/                                 # GitHub workflows, issue templates, CODEOWNERS
 ├── build/
 │   ├── build.sh                             # top-level build driver
@@ -118,18 +119,19 @@ DeepStream/
 ├── example_prompts/                         # example prompts for AI coding agents
 ├── includes/                                # shared public headers (ds3d, nvdsinferserver, …)
 ├── scripts/
-│   └── install_opensource_deps.sh           # builds open-source deps (OpenTelemetry, civetweb, …)
-├── tools/                                   # standalone tools
-│   ├── auto-magic-calib/                    # camera auto-calibration tool
-│   ├── inference_builder/                   # visual inference pipeline builder
-│   ├── sam2-onnx-tensorrt/                  # SAM2 ONNX-to-TensorRT conversion
-│   └── yolo_deepstream/                     # YOLO + TensorRT integration
-└── src/
-    ├── apps/                                # sample, reference, and TAO sample applications
-    ├── gst-plugins/                         # GStreamer plugin sources (per-plugin subdirs)
-    ├── gst-utils/                           # GStreamer utility libraries
-    ├── service-maker/                       # Service Maker C++/Python SDK and apps
-    └── utils/                               # utility library sources (per-library subdirs)
+│   ├── install_opensource_deps.sh           # builds open-source deps (OpenTelemetry, civetweb, …)
+│   └── print_env.sh                         # env diagnostic helper for bug reports
+├── src/
+│   ├── apps/                                # sample, reference, and TAO sample applications
+│   ├── gst-plugins/                         # GStreamer plugin sources (per-plugin subdirs)
+│   ├── gst-utils/                           # GStreamer utility library sources
+│   ├── service-maker/                       # Service Maker C++/Python SDK and apps
+│   └── utils/                               # utility library sources (per-library subdirs)
+└── tools/                                   # standalone tools
+    ├── auto-magic-calib/                    # camera auto-calibration tool
+    ├── inference_builder/                   # visual inference pipeline builder
+    ├── sam2-onnx-tensorrt/                  # SAM2 ONNX-to-TensorRT conversion
+    └── yolo_deepstream/                     # YOLO + TensorRT integration
 ```
 
 # Performance

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ deepstream-app -c source30_1080p_dec_infer-resnet_tiled_display.txt
 - More examples/tutorials: [DeepStream Quickstart Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Quickstart.html#run-deepstream-app-the-reference-application)
 - API reference: [DeepStream SDK Developer Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/)
 
+# Documentation
+
+| Page | Description |
+|------|-------------|
+| [Overview & Architecture](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Overview.html) | What DeepStream is, key features, and the GStreamer-based pipeline architecture. |
+| [Release Notes](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Release_notes.html) | What's new in this release, supported platforms, and known issues. |
+| [Installation](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html) | Step-by-step installation of the NVIDIA compute stack and DeepStream SDK on x86 and Jetson. |
+| [Docker Containers](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_docker_containers.html) | Available DeepStream NGC container images (incl. Triton variants) and how to pull and run them. |
+| [DeepStream Samples](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_C_Sample_Apps.html) | Reference walkthroughs of the bundled C/C++ sample applications and what each one demonstrates. |
+| [Reference Applications](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_ref_app_github.html) | Advanced GitHub-hosted reference apps demonstrating specialized end-to-end pipelines. |
+| [DeepStream Plugins](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_plugin_Intro.html) | Reference for every DeepStream GStreamer plugin — properties, pad caps, and usage. |
+| [Service Maker](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_service_maker_intro.html) | Build DeepStream pipelines declaratively with the C++ / Python Service Maker SDK. |
+| [Inference Builder](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Inference_Builder.html) | Compose and configure DeepStream inference pipelines visually with the Inference Builder tool. |
+| [DeepStream Coding Agent](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_AI_Agent.html) | Use the bundled `.agents/skills/` with Claude Code and other AI coding assistants to generate DeepStream pipelines. |
+
 # Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,42 +1,128 @@
 # DeepStream
-One-sentence value proposition for users. Who is it for, and why it matters. 
+
+[NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) is a streaming analytics toolkit for AI-based video and image understanding, providing a GStreamer-based framework to build multi-stream, multi-model inference pipelines on NVIDIA GPUs (dGPU and Jetson).
 
 # Overview
-What the project does? Why the project is useful?
-Provide a brief overview, highlighting key features or problem-solving capabilities.
+
+This repository contains the complete source code for DeepStream 9.0 — GStreamer plugins, utility libraries, sample applications, reference applications, TAO-integrated apps, and the Service Maker C++/Python SDK.
+
+It also ships DeepStream-specific tools — [`inference_builder`](tools/inference_builder/README.md) (visual inference pipeline builder), [`auto-magic-calib`](tools/auto-magic-calib/README.md) (camera auto-calibration tool), [`yolo_deepstream`](tools/yolo_deepstream/README.md) (YOLO + TensorRT integration), and [`sam2-onnx-tensorrt`](tools/sam2-onnx-tensorrt/README.md) (SAM2 ONNX-to-TensorRT conversion) — under `tools/`, and product-local AI agent skills under [`.agents/skills/`](.agents/skills/README.md) (`deepstream-dev` for general DeepStream development, `deepstream-import-vision-model` for autonomous vision-model onboarding) for use with Claude Code and compatible coding agents.
+
+DeepStream pipelines combine hardware-accelerated decoding/encoding, TensorRT inference, object tracking, and message-broker integrations to deliver real-time video analytics across dGPU and Jetson platforms.
+
+# Requirements
+
+Before building, ensure the following are installed:
+
+- **NVIDIA compute stack** — driver, CUDA, cuDNN, and TensorRT at the versions listed below. See the [DeepStream SDK Installation Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html).
+- **DeepStream 9.0** — installed via the DS 9.0 public Debian package and its `install.sh`.
+
+> **SBSA / DGX Spark:** no DS deb package exists for this platform — use the NVIDIA SBSA Docker container, which bundles the compute stack and DeepStream. See [BUILD.md](build/BUILD.md).
 
 # Getting Started
-Guide users on how they can get started with the project. This should include basic installation step, quick-start examples 
+
 ```bash
-# Option A: Package manager (pip/conda/npm/etc.)
-<copy-paste install>
+# Install Git LFS (required for sample video streams used by some apps)
+sudo apt-get install git-lfs
 
-# Option B: Container
-docker run <image> <args>
+# Clone the repo with submodules
+git clone --recurse-submodules https://github.com/NVIDIA/DeepStream.git && cd DeepStream
 
-# Verify (hello world)
-<one-liner or ~10-line example>
+# Pull LFS-tracked files
+git lfs install && git lfs pull
+
+# Build
+sudo bash build/build.sh
 ```
-# Requirements
-Include a list of pre-requisites. 
-- OS/Arch: <summary or link to full matrix>
-- Runtime/Compiler: <versions>
-- GPU/Drivers (if applicable): CUDA <ver>, driver <ver>, etc.
+
+See **[build/BUILD.md](build/BUILD.md)** for full build instructions, including system package dependencies (x86, aarch64, SBSA / DGX Spark), `build/build.sh` usage and environment variables (`CUDA_VER`, `NVDS_VERSION`), and build output locations under `/opt/nvidia/deepstream/deepstream-9.0/`.
+
+**Supported Platforms**
+
+| Platform | Architecture | Notes |
+|---|---|---|
+| x86 dGPU | x86_64 | Ubuntu 24.04, CUDA 13.1, TensorRT 10.14.x, driver 590+ |
+| Jetson | aarch64 | JetPack 7.1 GA (CUDA 13.0, TensorRT 10.13.x) |
+| SBSA / DGX Spark | aarch64 | No DS tar/deb package; build and run inside the NVIDIA SBSA Docker container |
 
 # Usage
+
+After `sudo bash build/build.sh`, binaries are installed to `/opt/nvidia/deepstream/deepstream-9.0/bin/`. Run the reference `deepstream-app` with one of the sample configs:
+
 ```bash
-# Minimal runnable snippet (≤20 lines)
-<code>
+cd /opt/nvidia/deepstream/deepstream-9.0/samples/configs/deepstream-app
+deepstream-app -c source30_1080p_dec_infer-resnet_tiled_display.txt
+
+# After the first install, clear the GStreamer plugin cache if needed:
+rm -rf ~/.cache/gstreamer-1.0/
 ```
-- More examples/tutorials: <link>
-- API reference: <link>
 
-# Performance (Optional)
-Summary of benchmarks; link to detailed results and hardware used.
+Each app must be run from its source directory so relative config paths resolve correctly. Refer to the `README` inside each app directory for app-specific run instructions and config options.
 
-## Releases & Roadmap 
+## Running with Triton Inference Server (Docker)
+
+> **Optional.** Skip this if the bare-metal build above already works for you. Use the Triton container when you need Triton-backed inference, or when you're on SBSA / DGX Spark (where no native DS deb package exists).
+
+NVIDIA publishes a DeepStream Docker image bundled with Triton Inference Server.
+
+```bash
+# One-time NGC login (get an API key from https://ngc.nvidia.com)
+docker login nvcr.io           # username: $oauthtoken,  password: <NGC API key>
+
+# Pull the image (use 9.0-triton-arm-sbsa instead on SBSA / DGX Spark)
+docker pull nvcr.io/nvidia/deepstream:9.0-triton-multiarch
+
+# Launch with display (use 'fakesink' in your pipeline for headless)
+export DISPLAY=:0 && xhost +
+docker run -it --rm --gpus all --network=host \
+    -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix \
+    nvcr.io/nvidia/deepstream:9.0-triton-multiarch
+
+# Inside the container, run a Triton-backed sample
+cd /opt/nvidia/deepstream/deepstream-9.0/samples/configs/deepstream-app-triton
+deepstream-app -c source30_1080p_dec_infer-resnet_tiled_display.txt
+```
+
+**Prerequisites:** Docker (`docker-ce`), the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html), NVIDIA driver 590+, and an NGC API key. Triton sample model repos ship under `/opt/nvidia/deepstream/deepstream/samples/triton_model_repo/`. For gRPC-backed Triton, use `samples/configs/deepstream-app-triton-grpc/` instead.
+
+- More examples/tutorials: [DeepStream Quickstart Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Quickstart.html#run-deepstream-app-the-reference-application)
+- API reference: [DeepStream SDK Developer Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/)
+
+# Repository Structure
+
+```
+DeepStream/
+├── .agents/
+│   └── skills/                              # product-local AI agent skills
+│       ├── deepstream-dev/                  # general DS development skill
+│       └── deepstream-import-vision-model/  # autonomous vision-model onboarding skill
+├── .github/                                 # GitHub workflows, issue templates, CODEOWNERS
+├── build/
+│   ├── build.sh                             # top-level build driver
+│   └── BUILD.md                             # build instructions
+├── example_prompts/                         # example prompts for AI coding agents
+├── includes/                                # shared public headers (ds3d, nvdsinferserver, …)
+├── scripts/
+│   └── install_opensource_deps.sh           # builds open-source deps (OpenTelemetry, civetweb, …)
+├── tools/                                   # standalone tools
+│   ├── auto-magic-calib/                    # camera auto-calibration tool
+│   ├── inference_builder/                   # visual inference pipeline builder
+│   ├── sam2-onnx-tensorrt/                  # SAM2 ONNX-to-TensorRT conversion
+│   └── yolo_deepstream/                     # YOLO + TensorRT integration
+└── src/
+    ├── apps/                                # sample, reference, and TAO sample applications
+    ├── gst-plugins/                         # GStreamer plugin sources (per-plugin subdirs)
+    ├── gst-utils/                           # GStreamer utility libraries
+    ├── service-maker/                       # Service Maker C++/Python SDK and apps
+    └── utils/                               # utility library sources (per-library subdirs)
+```
+
+# Performance
+Summary of benchmarks; for detailed performance numbers and hardware used, refer to the [DeepStream Performance Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Performance.html).
+
+## Releases & Roadmap
 - Releases/Changelog: <link>
-- (Optional) Next milestones or link to `ROADMAP.md`.
+- **`deepstream_libraries`** is not currently part of this GitHub OSS repository. For details and usage, refer to the [DeepStream Libraries documentation](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Libraries.html).
   
 # Contribution Guidelines
 This project is currently not accepting contributions.
@@ -59,8 +145,11 @@ This project is currently not accepting contributions.
 Provide the channel for community communications.
 
 # References
-Provide a list of related references
+
+- [DeepStream NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/deepstream) — prebuilt runtime image (also bundles Triton).
+- [NVIDIA TAO Toolkit](https://developer.nvidia.com/tao-toolkit) — model training/optimization, source of the TAO sample apps.
+- [GStreamer documentation](https://gstreamer.freedesktop.org/documentation/) — underlying framework.
 
 # License
-This project is licensed under the Apache 2.0 License - see the LICENSE file for details
+This project is licensed under the Apache 2.0 License — see [LICENSE](./LICENSE) (also viewable on GitHub at https://github.com/NVIDIA/DeepStream/blob/main/LICENSE) for the full text.
 - SPDX-License-Identifier: Apache-2.0

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -123,26 +123,28 @@ Build and validation must be done **inside the Docker container**.
 
 ## Build and Install
 
-`build.sh` auto-detects the host platform and:
+`build/build.sh` auto-detects the host platform and:
 - On SBSA / DGX Spark: passes `AARCH64_IS_SBSA=1` to all Makefiles (both `aarch64` and `sbsa` report `uname -m` as `aarch64`; SBSA is identified by the absence of `/etc/nv_tegra_release`)
 - Builds and installs open-source dependencies (opentelemetry, civetweb, prometheus-cpp, azure-iot-sdk)
 - Builds all source components and installs them directly to `/opt/nvidia/deepstream/deepstream-<NVDS_VERSION>/`
 
+From the repo root:
+
 ```bash
-sudo bash build.sh
+sudo bash build/build.sh
 ```
 
 Default CUDA version is architecture-dependent (`13.1` for x86_64, `13.0` for aarch64/sbsa/DGX Spark). To override:
 
 ```bash
-sudo CUDA_VER=13.1 bash build.sh   # x86
-sudo CUDA_VER=13.0 bash build.sh   # aarch64
+sudo CUDA_VER=13.1 bash build/build.sh   # x86
+sudo CUDA_VER=13.0 bash build/build.sh   # aarch64
 ```
 
 To override the target DeepStream version (default: 9.0):
 
 ```bash
-sudo NVDS_VERSION=9.0 bash build.sh
+sudo NVDS_VERSION=9.0 bash build/build.sh
 ```
 
 After first run, clear the GStreamer plugin cache so it picks up newly installed plugins:
@@ -162,7 +164,7 @@ rm -rf ~/.cache/gstreamer-1.0/
 
 ## service-maker — Local Compilation
 
-Individual service-maker apps can be compiled locally without running `build.sh`.
+Individual service-maker apps can be compiled locally without running `build/build.sh`.
 From within any app directory (e.g. `src/service-maker/sources/apps/cpp/deepstream_test1_app/`):
 
 ```bash

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build and install all DeepStream mono-repo components.
-# Usage: bash build.sh [CUDA_VER=<ver>]
+# Build and install all DeepStream components from this repository.
+# Usage (run from repo root): bash build/build.sh [CUDA_VER=<ver>]
 set -e
 
 ARCH=$(uname -m)
@@ -23,6 +23,10 @@ NVDS_VERSION=${NVDS_VERSION:-9.0}
 SM_APP_BUILD=/tmp/ds-sm-apps
 SM_MOD_BUILD=/tmp/ds-sm-modules
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# build.sh lives in build/; cd to the repo root so the relative
+# make -C tools/... and src/... paths below resolve regardless of where
+# the script was invoked from.
+cd "$SCRIPT_DIR/.."
 
 # Extra make flags for SBSA — passes AARCH64_IS_SBSA=1 to all Makefiles
 PLATFORM_MAKE_FLAGS=

--- a/scripts/print_env.sh
+++ b/scripts/print_env.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2026, NVIDIA CORPORATION.
 # Reports relevant environment information useful for diagnosing and
 # debugging DeepStream issues.
 # Usage:
-# "./print_env.sh" - prints to stdout
-# "./print_env.sh > env.txt" - prints to file "env.txt"
+# "./scripts/print_env.sh" - prints to stdout
+# "./scripts/print_env.sh > env.txt" - prints to file "env.txt"
 
 print_env() {
 echo "**git***"

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,103 @@
+# DeepStream Source Tree
+
+This directory contains the source for all DeepStream 9.0 components shipped from this repository, along with platform-specific notes, external-prerequisite caveats, and deprecation status.
+
+For build and install instructions, see [BUILD.md](../build/BUILD.md).
+
+---
+
+## Components
+
+### Sample Applications
+
+Located in `apps/sample_apps/`. These apps demonstrate core DeepStream pipeline patterns using GStreamer APIs directly.
+
+See [`apps/sample_apps/README.md`](apps/sample_apps/README.md) for the full list with descriptions and run commands. Each app has its own `README` at `apps/sample_apps/<app>/README`.
+
+### Reference Applications
+
+Located in `apps/reference_apps/`. Advanced apps demonstrating specialized use cases.
+
+See [`apps/reference_apps/README.md`](apps/reference_apps/README.md) for details. Each app has its own `README` at `apps/reference_apps/<app>/README`.
+
+### TAO Apps
+
+Located in `apps/tao_apps/`. Sample applications for running [NVIDIA TAO Toolkit](https://developer.nvidia.com/tao-toolkit) models with DeepStream.
+
+See [`apps/tao_apps/README.md`](apps/tao_apps/README.md) for supported models, build, and run instructions.
+
+Supported models include: PeopleNet Transformer, CitySemSegFormer, Mask2Former, Re-Identification, BodyPose3DNet, PoseClassification, OCDNet, OCRNet, LPDNet, LPRNet, Retail Detector, Retail Object Recognition.
+
+### Service Maker
+
+Located in `service-maker/`. A C++ and Python SDK that abstracts GStreamer/GLib APIs for building DeepStream applications declaratively.
+
+See [`service-maker/README.md`](service-maker/README.md) for build instructions, API overview, and app list. See also the [Service Maker introduction](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_service_maker_intro.html).
+
+- **C++ apps** — `service-maker/sources/apps/cpp/`
+- **Python apps** — `service-maker/sources/apps/python/` (flow API and pipeline API)
+- **Modules** — reusable signal handlers, probes, video sinks/sources, and more
+
+### GStreamer Plugins
+
+Located in `gst-plugins/`. Source for all DeepStream GStreamer plugins.
+
+See [`gst-plugins/README.md`](gst-plugins/README.md) for the full list. Each plugin has its own `README` at `gst-plugins/<plugin>/README` with properties and usage. See also the [DeepStream Plugins introduction](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_plugin_Intro.html).
+
+### GStreamer Utilities
+
+Located in `gst-utils/`. Each utility has its own `README` at `gst-utils/<utility>/README`:
+
+- [`gstnvcustomhelper`](gst-utils/gstnvcustomhelper/README)
+- [`gstnvdscustomhelper`](gst-utils/gstnvdscustomhelper/README)
+- [`gst-nvdssr`](gst-utils/gst-nvdssr/README)
+
+### Utility Libraries
+
+Located in `utils/`.
+
+See [`utils/README.md`](utils/README.md) for the full list. Each library has its own `README` at `utils/<library>/README`.
+
+---
+
+## Platform-Specific Components
+
+| Component | Platform | Notes |
+|---|---|---|
+| `deepstream-ipc-test` | Jetson (aarch64) only | Relies on NVDEC engine sharing not available on x86 or SBSA |
+| `deepstream-multigpu-nvlink-test` | x86 dGPU only | Requires NVLink; not supported on Jetson |
+
+## Components with External Prerequisites
+
+The following components build successfully only when the listed external SDK is installed on the system. See each component's README for installation links and setup details.
+
+| Component | External Prerequisite | Details |
+|---|---|---|
+| `gst-dsexample-cuda` | OpenCV 4.x built with CUDA support | [gst-plugins/gst-dsexample-cuda/README](gst-plugins/gst-dsexample-cuda/README) |
+| `gst-nvdsudp` | Rivermax SDK (`rivermax_api.h`) | [gst-plugins/gst-nvdsudp/README](gst-plugins/gst-nvdsudp/README) |
+| `libnvdsgst_inferserver` | Triton Inference Server client | [gst-plugins/gst-nvinferserver/README](gst-plugins/gst-nvinferserver/README) |
+
+---
+
+## Deprecated Components
+
+The following components are **legacy and no longer maintained**. They are still shipped with the DeepStream 9.0 public release but have been excluded from this repository. Deprecation was announced as part of the DS 9.0 public release.
+
+### Sample Applications
+
+- `deepstream-audio`
+- `deepstream-avsync`
+- `deepstream-mrcnn-test`
+- `deepstream-segmentation-test`
+- `deepstream-ucx-test`
+- `deepstream_asr_app`
+- `deepstream_asr_tts_app`
+
+### GStreamer Plugins
+
+- `gst-nvdsA2Vtemplate`
+- `gst-nvdsaudiotemplate`
+- `gst-nvdsspeech`
+- `gst-nvdstexttospeech`
+
+For component details, source, and configuration, refer to the [DeepStream 9.0 public release documentation](https://docs.nvidia.com/metropolis/deepstream/dev-guide).

--- a/src/apps/sample_apps/README.md
+++ b/src/apps/sample_apps/README.md
@@ -14,13 +14,13 @@ its affiliates is strictly prohibited.
 
 This directory contains GStreamer-based DeepStream sample applications. Each app demonstrates a specific pipeline pattern or feature of the DeepStream SDK.
 
-For build and installation instructions, see the repo root [BUILD.md](../../../BUILD.md).
+For build and installation instructions, see [build/BUILD.md](../../../build/BUILD.md).
 
 ---
 
 ## Running Apps
 
-After `build.sh`, binaries are installed to `/opt/nvidia/deepstream/deepstream-9.0/bin/`.
+After `build/build.sh`, binaries are installed to `/opt/nvidia/deepstream/deepstream-9.0/bin/`.
 
 Apps must be run from their **source directory** so relative config and model paths resolve correctly:
 

--- a/src/gst-plugins/README.md
+++ b/src/gst-plugins/README.md
@@ -14,7 +14,7 @@ its affiliates is strictly prohibited.
 
 This directory contains source code for all DeepStream GStreamer plugins. Each plugin is a self-contained GStreamer element that integrates with the DeepStream metadata pipeline.
 
-For build and installation instructions, see the repo root [BUILD.md](../../BUILD.md).
+For build and installation instructions, see [build/BUILD.md](../../build/BUILD.md).
 
 ---
 

--- a/src/service-maker/README.md
+++ b/src/service-maker/README.md
@@ -36,19 +36,19 @@ service-maker/
 
 ## Prerequisites
 
-- DeepStream 9.0 installed (via `build.sh` or the Debian package + `install.sh`)
+- DeepStream 9.0 installed (via `build/build.sh` or the Debian package + `install.sh`)
 - CMake 3.16+
 - GCC 9+
 
-For full system dependency setup, see the repo root [BUILD.md](../../BUILD.md).
+For full system dependency setup, see [build/BUILD.md](../../build/BUILD.md).
 
 ---
 
 ## Build
 
-### Full Build (via build.sh)
+### Full Build (via build/build.sh)
 
-Service Maker apps are built automatically as part of the top-level `build.sh`. Binaries are installed to:
+Service Maker apps are built automatically as part of the top-level `build/build.sh`. Binaries are installed to:
 
 ```
 /opt/nvidia/deepstream/deepstream-9.0/bin/service-maker-<app>
@@ -62,7 +62,7 @@ Modules are installed to:
 
 ### Local CMake Build (single app)
 
-Individual apps can be built and run locally without `build.sh`:
+Individual apps can be built and run locally without `build/build.sh`:
 
 ```bash
 cd sources/apps/cpp/<app-name>

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -14,7 +14,7 @@ its affiliates is strictly prohibited.
 
 This directory contains source code for DeepStream utility libraries — shared libraries consumed by GStreamer plugins, sample applications, and service-maker modules.
 
-For build and installation instructions, see the repo root [BUILD.md](../../BUILD.md).
+For build and installation instructions, see [build/BUILD.md](../../build/BUILD.md).
 
 ---
 

--- a/src/utils/ds3d/README.md
+++ b/src/utils/ds3d/README.md
@@ -45,4 +45,4 @@ ds3d/
 | `deepstream-3d-action-recognition` | 3D action recognition from video |
 | `deepstream-lidar-inference-app` | Standalone LiDAR object detection |
 
-For build and installation, see the repo root [BUILD.md](../../../BUILD.md).
+For build and installation, see [build/BUILD.md](../../../build/BUILD.md).

--- a/src/utils/nvds_msgapi/README.md
+++ b/src/utils/nvds_msgapi/README.md
@@ -39,4 +39,4 @@ The `nvmsgbroker` plugin selects an adaptor at runtime via the `config-file` pro
 
 See the `deepstream-test4` sample app for an end-to-end example of publishing inference results to a message broker.
 
-For build and installation, see the repo root [BUILD.md](../../../BUILD.md).
+For build and installation, see [build/BUILD.md](../../../build/BUILD.md).


### PR DESCRIPTION
## Summary

Fills out the OSS top-level README with real content (replacing the PLC template skeleton), adds a `src/README.md` components index, and relocates build and env-print scripts under cleaner top-level folders. All cross-file references and links updated.

## Commit 1 — `docs: fill OSS README from mono-repo, add src/README, relocate build and print_env`

**`README.md`** — full rewrite of the PLC template:
- Overview with inline mention of `inference_builder`, `auto-magic-calib`, `yolo_deepstream`, `sam2-onnx-tensorrt`, and `.agents/skills/` (`deepstream-dev`, `deepstream-import-vision-model`)
- Requirements + Supported Platforms table (x86 dGPU, Jetson, SBSA / DGX Spark)
- Getting Started clone + LFS + build snippet
- Usage section with `deepstream-app` example **and** a Triton-via-Docker subsection (NGC pull + run)
- Repository Structure tree showing `build/`, `scripts/`, `tools/`, `src/`, `.agents/`, `example_prompts/`
- Performance pointer to the DS Performance Guide
- Releases & Roadmap note that `deepstream_libraries` is not in this OSS repo (with link)
- License section links to `./LICENSE` + GitHub URL

**`src/README.md`** (new) — components index ported from mono-repo:
- Components (Sample Apps, Reference Apps, TAO Apps, Service Maker, GStreamer Plugins, GStreamer Utilities, Utility Libraries)
- Platform-Specific Components table (`deepstream-ipc-test`, `deepstream-multigpu-nvlink-test`)
- Components with External Prerequisites table (`gst-dsexample-cuda`, `gst-nvdsudp`, `libnvdsgst_inferserver`)
- Deprecated Components list

**`.agents/skills/README.md`** — drop redundant Project Structure, Additional Resources, Contributing, License sections (root README owns those now).

**`LICENSE`** — copyright year `2020 → 2026`.

**Script relocations** (via `git mv`, exec bits preserved):
- `print_env.sh → scripts/print_env.sh` — copyright bumped `2023 → 2026`; usage examples updated. Both `.github/ISSUE_TEMPLATE/` references updated.
- `build.sh → build/build.sh` — added `cd \"\$SCRIPT_DIR/..\"` so relative `tools/`, `src/` paths still resolve; header comment updated.
- `BUILD.md → build/BUILD.md` — example invocations switched to `bash build/build.sh` (5 occurrences).

**Cross-file link updates** — all `BUILD.md` link paths re-pathed under `build/` in: `src/README.md`, `src/apps/sample_apps/README.md`, `src/gst-plugins/README.md`, `src/service-maker/README.md`, `src/utils/README.md`, `src/utils/ds3d/README.md`, `src/utils/nvds_msgapi/README.md`.

## Commit 2 — `docs(README): add Documentation section linking to DS dev-guide pages`

New `# Documentation` table between Usage and Repository Structure, format mirrored from [NemoClaw](https://github.com/NVIDIA/NemoClaw#documentation). 10 dev-guide entries: Overview & Architecture, Release Notes, Installation, Docker Containers, DeepStream Samples, Reference Applications, DeepStream Plugins, Service Maker, Inference Builder, DeepStream Coding Agent.

## Notes

- README's Overview already links to `tools/inference_builder/README.md` and `tools/auto-magic-calib/README.md` per direction to "mention everything now"; those two paths will become valid once the IB and AMC migrations land.

## Test plan

- [ ] Verify README and src/README render correctly on GitHub
- [ ] Verify all internal markdown links resolve on the rendered page
- [ ] Verify `bash build/build.sh` still works from repo root (the `cd \"\$SCRIPT_DIR/..\"` patch)
- [ ] Verify `bash scripts/print_env.sh` still works from repo root
- [ ] Verify `.github/ISSUE_TEMPLATE/bug_report.md` and `bug_report_form.yml` reference the new `scripts/print_env.sh` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)