### PR TITLE
Add x86-only deepstream-ucx-test sample app and dual-license LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,406 @@
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+This code is dual-licensed with documentation under the CC-BY-4.0 AND source code under Apache-2.0 license terms.
+
+
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +451,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
+      submitted to the Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +463,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
+      on behalf of whom a Contribution has been received by the Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +509,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
+          within such NOTICE file, excluding any notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -175,18 +578,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 NVIDIA Corporation
+   Copyright 2026 NVIDIA CORPORATION
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -578,6 +578,16 @@ Creative Commons may be contacted at creativecommons.org.
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
    Copyright 2026 NVIDIA CORPORATION
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 
 [NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) is a streaming analytics toolkit for AI-based video and image understanding, providing a GStreamer-based framework to build multi-stream, multi-model inference pipelines on NVIDIA GPUs (dGPU and Jetson).
 
+DeepStream pipelines combine hardware-accelerated decoding/encoding, TensorRT inference, object tracking, and message-broker integrations to deliver real-time video analytics across dGPU and Jetson platforms.
+
 # Overview
 
 This repository contains the complete source code for DeepStream 9.0 — GStreamer plugins, utility libraries, sample applications, reference applications, TAO-integrated apps, and the Service Maker C++/Python SDK.
 
-It also ships DeepStream-specific tools — [`inference_builder`](tools/inference_builder/README.md) (visual inference pipeline builder), [`auto-magic-calib`](tools/auto-magic-calib/README.md) (camera auto-calibration tool), [`yolo_deepstream`](tools/yolo_deepstream/README.md) (YOLO + TensorRT integration), and [`sam2-onnx-tensorrt`](tools/sam2-onnx-tensorrt/README.md) (SAM2 ONNX-to-TensorRT conversion) — under `tools/`, and product-local AI agent skills under [`.agents/skills/`](.agents/skills/README.md) (`deepstream-dev` for general DeepStream development, `deepstream-import-vision-model` for autonomous vision-model onboarding) for use with Claude Code and compatible coding agents.
+**Tools** (`tools/`):
+- [`inference_builder`](tools/inference_builder/README.md) — visual inference pipeline builder
+- [`auto-magic-calib`](tools/auto-magic-calib/README.md) — camera auto-calibration tool
+- [`yolo_deepstream`](tools/yolo_deepstream/README.md) — YOLO + TensorRT integration
+- [`sam2-onnx-tensorrt`](tools/sam2-onnx-tensorrt/README.md) — SAM2 ONNX-to-TensorRT conversion
 
-DeepStream pipelines combine hardware-accelerated decoding/encoding, TensorRT inference, object tracking, and message-broker integrations to deliver real-time video analytics across dGPU and Jetson platforms.
+**AI agent skills** ([`.agents/skills/`](.agents/skills/README.md), for Claude Code & compatible coding agents):
+- `deepstream-dev` — general DeepStream development
+- `deepstream-import-vision-model` — autonomous vision-model onboarding
 
 # Requirements
 
-Before building, ensure the following are installed:
+Before building, ensure the following prerequisites are installed:
 
 - **NVIDIA compute stack** — driver, CUDA, cuDNN, and TensorRT at the versions listed below. See the [DeepStream SDK Installation Guide](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html).
 - **DeepStream 9.0** — installed via the DS 9.0 public Debian package and its `install.sh`.
 
-> **SBSA / DGX Spark:** no DS deb package exists for this platform — use the NVIDIA SBSA Docker container, which bundles the compute stack and DeepStream. See [BUILD.md](build/BUILD.md).
+> **SBSA / DGX Spark:** no DS deb package exists for this platform — use the NVIDIA SBSA Docker container, which bundles the compute stack and DeepStream. See [build/BUILD.md](build/BUILD.md).
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -176,5 +176,5 @@ Provide the channel for community communications.
 - [GStreamer documentation](https://gstreamer.freedesktop.org/documentation/) — underlying framework.
 
 # License
-This project is licensed under [CC-BY-4.0 AND Apache-2.0](./LICENSE) (also viewable on GitHub at https://github.com/NVIDIA/DeepStream/blob/main/LICENSE).
+This project is licensed under [CC-BY-4.0 AND Apache-2.0](./LICENSE).
 - SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0

--- a/README.md
+++ b/README.md
@@ -168,5 +168,5 @@ Provide the channel for community communications.
 - [GStreamer documentation](https://gstreamer.freedesktop.org/documentation/) — underlying framework.
 
 # License
-This project is licensed under the Apache 2.0 License — see [LICENSE](./LICENSE) (also viewable on GitHub at https://github.com/NVIDIA/DeepStream/blob/main/LICENSE) for the full text.
-- SPDX-License-Identifier: Apache-2.0
+This project is licensed under [CC-BY-4.0 AND Apache-2.0](./LICENSE) (also viewable on GitHub at https://github.com/NVIDIA/DeepStream/blob/main/LICENSE).
+- SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0

--- a/build/build.sh
+++ b/build/build.sh
@@ -124,6 +124,11 @@ SA_BIN_STAGE=/tmp/ds-sample-apps-bin
 DS_BIN=/opt/nvidia/deepstream/deepstream-${NVDS_VERSION}/bin
 mkdir -p "$SA_BIN_STAGE"
 for dir in src/apps/sample_apps/*/; do
+  # deepstream-ucx-test is x86-only (no aarch64 UCX support shipped)
+  if [ "$PLATFORM" != "x86" ] && [ "$(basename "$dir")" = "deepstream-ucx-test" ]; then
+    echo "Skipping deepstream-ucx-test on $PLATFORM (x86 only)"
+    continue
+  fi
   make -C "$dir" $MK BIN_DIR="$SA_BIN_STAGE" 2>/dev/null || true
   for bin in "$SA_BIN_STAGE"/deepstream-*; do
     [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true

--- a/src/README.md
+++ b/src/README.md
@@ -66,6 +66,7 @@ See [`utils/README.md`](utils/README.md) for the full list. Each library has its
 |---|---|---|
 | `deepstream-ipc-test` | Jetson (aarch64) only | Relies on NVDEC engine sharing not available on x86 or SBSA |
 | `deepstream-multigpu-nvlink-test` | x86 dGPU only | Requires NVLink; not supported on Jetson |
+| `deepstream-ucx-test` | x86 only | No UCX support shipped for aarch64 or SBSA; skipped by `build/build.sh` on those platforms |
 
 ## Components with External Prerequisites
 
@@ -89,7 +90,6 @@ The following components are **legacy and no longer maintained**. They are still
 - `deepstream-avsync`
 - `deepstream-mrcnn-test`
 - `deepstream-segmentation-test`
-- `deepstream-ucx-test`
 - `deepstream_asr_app`
 - `deepstream_asr_tts_app`
 

--- a/src/apps/sample_apps/deepstream-ucx-test/Makefile
+++ b/src/apps/sample_apps/deepstream-ucx-test/Makefile
@@ -1,0 +1,58 @@
+################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+################################################################################
+
+CUDA_VER?=
+ifeq ($(CUDA_VER),)
+  $(error "CUDA_VER is not set")
+endif
+
+APP:= deepstream-ucx-test-app
+include ../Rules.mk
+
+NVDS_VERSION?=9.0
+
+LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
+APP_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/bin/
+
+SRCS:= deepstream_ucx_test_app.c
+
+INCS:= $(wildcard *.h)
+
+PKGS:= gstreamer-1.0
+
+OBJS:= $(SRCS:.c=.o)
+OBJS:= $(addprefix $(OBJ_DIR)/,$(OBJS))
+
+CFLAGS+= -fPIC -I../../../../includes \
+	 -I /usr/local/cuda-$(CUDA_VER)/include
+
+CFLAGS+= $(shell pkg-config --cflags $(PKGS))
+
+LIBS:= $(shell pkg-config --libs $(PKGS))
+
+LIBS+= -L/usr/local/cuda-$(CUDA_VER)/lib64/ -lcudart \
+       -lcuda -Wl,-rpath,$(LIB_INSTALL_DIR)
+
+all: $(BIN_DIR)/$(APP)
+
+$(OBJ_DIR)/%.o: %.c $(INCS) Makefile
+	@mkdir -p $(OBJ_DIR)
+	$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BIN_DIR)/$(APP): $(OBJS) Makefile
+	@mkdir -p $(BIN_DIR)
+	$(CXX) -o $(BIN_DIR)/$(APP) $(OBJS) $(LIBS)
+
+install: $(BIN_DIR)/$(APP)
+
+clean:
+	rm -rf $(OBJ_DIR) $(BIN_DIR)/$(APP)

--- a/src/apps/sample_apps/deepstream-ucx-test/README
+++ b/src/apps/sample_apps/deepstream-ucx-test/README
@@ -1,0 +1,236 @@
+*****************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+*****************************************************************************
+
+*****************************************************************************
+                     deepstream-ucx-test-app
+                             README
+*****************************************************************************
+
+===============================================================================
+1. Prerequisites:
+===============================================================================
+
+Please follow instructions in the apps/sample_apps/deepstream-app/README on how
+to install the prerequisites for Deepstream SDK, the DeepStream SDK itself and
+the apps. Also, please read the information about the Gst-NvDsUcx plugin within
+the Deepstream SDK.
+
+This test requires the availability of an NVIDIA ConnectX-6 DX or later NIC.
+For more information on installing and configuring NICs, please see:
+https://docs.nvidia.com/networking/display/ConnectX6VPI/Introduction
+
+To be able to run the test over an RDMA-enabled network, please ensure you have
+also installed the RDMA OFED network stack from here:
+https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/
+The installation instructions can be found here:
+https://docs.nvidia.com/networking/display/MLNXOFEDv551032/Installing+MLNX_OFED
+
+Also, install the Unified Communication-X Library from here:
+https://github.com/openucx/ucx.
+The installation instructions are mentioned here:
+https://github.com/openucx/ucx#release-builds.
+Please note, that UCX library should be compiled with CUDA support by adding the
+--with-cuda=<path/to/cuda>
+to the configure command:
+
+$ ./contrib/configure-release-mt --prefix=/install/path --with-cuda=/path/to/\
+  cuda
+
+You must have the following development packages installed
+   GStreamer-1.0
+   GStreamer-1.0 Base Plugins
+   GStreamer-1.0 gstrtspserver
+   X11 client-side library
+
+To install these packages, execute the following command:
+   sudo apt-get install libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
+   libgstrtspserver-1.0-dev libx11-dev
+
+===============================================================================
+2. Purpose:
+===============================================================================
+This documents describes the sample deepstream-ucx-test application.
+
+The deepstream-ucx-test application is meant for a demonstration of how to use
+the communication plugin called nvdsgst_ucx with the Deepstream SDK.
+
+Test 1: Basic Video Transmission
+   This test is centered on the basic transmission of video frames over an RDMA
+   network.
+
+   Server:
+      - uridecoder: Reads and decodes the video.
+      - streammux: Combines streams and appends metadata.
+      - nvdsgst_ucx: Server acts as sink, sending data.
+
+   Client:
+      - nvdsgst_ucx: Client acts as source, Receives data from the server.
+      - streamdemux: Splits the multiplexed streams.
+      - video converter: Converts video formats.
+      - h264 encoder: Encodes the video.
+      - h264 parser: Parses the encoded video.
+      - qtmux: Packages into MP4 format.
+      - filesink: Writes the processed video to a file.
+
+Test 2: Video with Metadata Serialization
+   This test involves the transmission of video frames with associated metadata
+   serialized using the Gst-NvDsMetaUtils library.
+
+   Client:
+      - filesrc: Reads video data.
+      - streammux: Combines streams after decoding.
+      - nvinfer/nvinferserver: Identifies specific objects in frames, adding
+      metadata.
+      - video serialization plugin: Converts metadata to a binary format.
+      - nvdsgst_ucx: Client acts as a sink, sending frames and binary metadata
+      over the RDMA network to the server.
+
+   Server:
+      - nvdsgst_ucx: Server acts as source, receiving data from the client.
+      - video deserialization plugin: Extracts and appends metadata to frames.
+      - nvdsosd: Interprets the metadata.
+      - videoconverter: Adapts video to the correct format.
+      - encoder: Encodes the video.
+      - qtmux: Splits multiplexed data
+      - filesink: Outputs the processed video to a file.
+
+Test 3: Audio with Metadata Serialization
+This test concentrates on the transmission of audio data embedded with
+serialized metadata via the Gst-NvDsMetaUtils library.
+
+   Server:
+      - uri_decode_bin: Extracts audio from a file.
+      - nvstreammux: Combines audio streams.
+      - audio serialization plugin: Reads metadata added by nvstreammux,
+      serializes it, and appends to the buffer.
+      - nvdsgst_ucx : Server acts as sink, sends the NVAudio buffer's audio
+      data and serialized metadata.
+
+   Client:
+      - nvdsgst_ucx: Client acts as source, receives audio and metadata.
+      - audio deserialization plugin: Extracts and appends metadata to frames.
+      - demux: Splits multiplexed audio data.
+      - audio_converter: Adapts audio to the correct format.
+      - filesink: Writes the processed audio to a file.
+
+===============================================================================
+3. To compile:
+===============================================================================
+
+  Set CUDA_VER to 13.2 for x86. The Deepstream UCX plugin does not work in
+  Jetson.
+  $ export CUDA_VER=13.2
+  $ sudo make (sudo not required in case of docker containers)
+
+  Note, the nvdsgst_ucx plugin is not supported on Jetson.
+
+===============================================================================
+4. Usage:
+===============================================================================
+
+Compilation: To compile the sources, run make with "sudo" or root permission.
+
+Test 1:
+   Server Setup:
+   $ ./deepstream-ucx-test-app -t 1 -s <IP> <PORT> <HEIGHT> <WIDTH> \
+   <VIDEO_URI>
+
+   Client Setup:
+   After starting the server, initiate the client application.
+   $ ./deepstream-ucx-test-app -t 1 -c <SERVER_IP> <SERVER_PORT> <HEIGHT> \
+   <WIDTH> <SAVE_PATH>
+
+   Example:
+   Server:
+   $ ./deepstream-ucx-test-app -t 1 -s 192.168.100.1 4000 1920 1080 \
+   file:////opt/nvidia/deepstream/deepstream/samples/streams/\
+   sample_1080p_h264.mp4
+
+   Client:
+   $ ./deepstream-ucx-test-app -t 1 -c 192.168.100.1 4000 1920 1080 \
+   output.mp4
+
+Test 2:
+   Pre-requisites:
+   Navigate to the video_metadata_serialization directory and compile the
+   library:
+   $ cd /opt/nvidia/deepstream/deepstream/sources/gst-plugins/\
+   gst-nvdsmetautils/video_metadata_serialization
+   $ make
+   $ sudo make install
+
+   Set the necessary environment variable:
+   $ export USE_NEW_NVSTREAMMUX=yes
+
+
+   Server Setup:
+   $ ./deepstream-ucx-test-app -t 2 -s <IP> <PORT> <HEIGHT> <WIDTH> \
+   <METADATA_LIB_PATH> <OUTPUT_PATH>
+
+   Client Setup:
+   After initiating the server, launch the client application.
+   $ ./deepstream-ucx-test-app -t 2 -c <SERVER_IP> <SERVER_PORT> \
+   <NVINFER_CONFIG_PATH> <METADATA_LIB_PATH> <VIDEO_PATH>
+
+   Use option "-i" and provide inferserver config file to select nvinferserver
+   as the inference plugin:
+   $ ./deepstream-ucx-test-app -t 2 -c -i <SERVER_IP> <SERVER_PORT> \
+   <INFERSERVER_CONFIG_PATH> <METADATA_LIB_PATH> <VIDEO_PATH>
+
+   Example:
+   Server:
+   $ USE_NEW_NVSTREAMMUX=yes ./deepstream-ucx-test-app -t 2 -s 192.168.100.1\
+   4000 1920 1080 /opt/nvidia/deepstream/deepstream/lib/\
+   libnvds_video_metadata_serialization.so output.mp4
+
+   Client:
+   $ USE_NEW_NVSTREAMMUX=yes ./deepstream-ucx-test-app -t 2 -c 192.168.100.1\
+   4000 /opt/nvidia/deepstream/deepstream/samples/configs/deepstream-app/\
+   config_infer_primary.txt /opt/nvidia/deepstream/deepstream/lib/\
+   libnvds_video_metadata_serialization.so /opt/nvidia/deepstream/deepstream\
+   /samples/streams/sample_1080p_h264.mp4
+
+
+
+Test 3:
+   Pre-requisites:
+   Navigate to the audio_metadata_serialization directory and compile the
+   library:
+   $ cd /opt/nvidia/deepstream/deepstream/sources/gst-plugins/\
+   gst-nvdsmetautils/audio_metadata_serialization
+   $ make
+   $ sudo make install
+
+   Set the environment variable:
+   $ export USE_NEW_NVSTREAMMUX=yes
+
+   Server Setup:
+   $ ./deepstream-ucx-test-app -t 3 -s <IP> <PORT> \
+   <AUDIO_METADATA_LIB_PATH> <INPUT_FILE_PATH>
+
+   Client Setup:
+   After starting the server, run the client application.
+   $ ./deepstream-ucx-test-app -t 3 -c <SERVER_IP> <SERVER_PORT> \
+   <AUDIO_METADATA_LIB_PATH> <OUTPUT_AUDIO_PATH>
+
+   Example:
+   Server:
+   $ USE_NEW_NVSTREAMMUX=yes ./deepstream-ucx-test-app -t 3 -s 192.168.100.1\
+   4000 /opt/nvidia/deepstream/deepstream/lib/\
+   libnvds_audio_metadata_serialization.so \
+   file:////opt/nvidia/deepstream/deepstream/samples/streams/\
+   sonyc_mixed_audio.wav
+
+   Client:
+   $ USE_NEW_NVSTREAMMUX=yes ./deepstream-ucx-test-app -t 3 -c 192.168.100.1\
+   4000 /opt/nvidia/deepstream/deepstream/lib/\
+   libnvds_audio_metadata_serialization.so out.wav

--- a/src/apps/sample_apps/deepstream-ucx-test/deepstream_ucx_test_app.c
+++ b/src/apps/sample_apps/deepstream-ucx-test/deepstream_ucx_test_app.c
@@ -1,0 +1,960 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+#include <gst/gst.h>
+#include <glib.h>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include "deepstream_ucx_test_app.h"
+
+
+static gboolean
+bus_call (GstBus * bus, GstMessage * msg, gpointer data)
+{
+  GMainLoop *loop = (GMainLoop *) data;
+  switch (GST_MESSAGE_TYPE (msg)) {
+    case GST_MESSAGE_EOS:
+      g_print ("End of stream\n");
+      g_main_loop_quit (loop);
+      break;
+    case GST_MESSAGE_ERROR:{
+      gchar *debug = NULL;
+      GError *error = NULL;
+      gst_message_parse_error (msg, &error, &debug);
+      g_printerr ("ERROR from element %s: %s\n",
+          GST_OBJECT_NAME (msg->src), error->message);
+      if (debug)
+        g_printerr ("Error details: %s\n", debug);
+      g_free (debug);
+      g_error_free (error);
+      g_main_loop_quit (loop);
+      break;
+    }
+    default:
+      break;
+  }
+  return TRUE;
+}
+
+static void
+cb_newpad_audio (GstElement * decodebin, GstPad * decoder_src_pad, gpointer data)
+{
+  g_print ("In cb_newpad\n");
+  GstCaps *caps = gst_pad_get_current_caps (decoder_src_pad);
+  const GstStructure *str = gst_caps_get_structure (caps, 0);
+  const gchar *name = gst_structure_get_name (str);
+  GstElement *source_bin = (GstElement *) data;
+
+  /* Need to check if the pad created by the decodebin is for audio and not
+   * video. */
+  if (!strncmp (name, "audio", 5)) {
+    /* Get the source bin ghost pad */
+    GstPad *bin_ghost_pad = gst_element_get_static_pad (source_bin, "src");
+    if (!gst_ghost_pad_set_target (GST_GHOST_PAD (bin_ghost_pad),
+            decoder_src_pad)) {
+      g_printerr ("Failed to link decoder src pad to source bin ghost pad\n");
+    }
+    gst_object_unref (bin_ghost_pad);
+  }
+}
+
+static void
+cb_newpad_video_server (GstElement * decodebin, GstPad * decoder_src_pad,
+    gpointer data)
+{
+  g_print ("In cb_newpad\n");
+  GstCaps *caps = gst_pad_get_current_caps (decoder_src_pad);
+  const GstStructure *str = gst_caps_get_structure (caps, 0);
+  const gchar *name = gst_structure_get_name (str);
+  GstElement *source_bin = (GstElement *) data;
+  GstCapsFeatures *features = gst_caps_get_features (caps, 0);
+
+  /* Need to check if the pad created by the decodebin is for video and not
+   * audio. */
+  if (!strncmp (name, "video", 5)) {
+    /* Link the decodebin pad only if decodebin has picked nvidia
+     * decoder plugin nvdec_*. We do this by checking if the pad caps contain
+     * NVMM memory features. */
+    if (gst_caps_features_contains (features, GST_CAPS_FEATURES_NVMM)) {
+      /* Get the source bin ghost pad */
+      GstPad *bin_ghost_pad = gst_element_get_static_pad (source_bin, "src");
+      if (!gst_ghost_pad_set_target (GST_GHOST_PAD (bin_ghost_pad),
+              decoder_src_pad)) {
+        g_printerr ("Failed to link decoder src pad to source bin ghost pad\n");
+      }
+      gst_object_unref (bin_ghost_pad);
+    } else {
+      g_printerr ("Error: Decodebin did not pick nvidia decoder plugin.\n");
+    }
+  }
+}
+
+static void
+cb_newpad_client (GstElement * decodebin, GstPad * demux_src_pad, gpointer data)
+{
+  g_print ("In cb_newpad\n");
+  GstCaps *caps = gst_pad_get_current_caps (demux_src_pad);
+  const GstStructure *str = gst_caps_get_structure (caps, 0);
+  const gchar *name = gst_structure_get_name (str);
+  GstElement *h264sink = (GstElement *) data;
+
+  /* Need to check if the pad created by the qtdemux is for video and not
+   * audio. */
+  if (!strncmp (name, "video", 5)) {
+    g_print ("Qtdemux src pad: %s\n", name);
+    GstPad *sinkpad = gst_element_get_static_pad (h264sink, "sink");
+
+    if (gst_pad_is_linked (sinkpad)) {
+      g_printerr ("h264 parser sink pad already linked.\n");
+      return;
+    }
+
+    if (gst_pad_link (demux_src_pad, sinkpad) != GST_PAD_LINK_OK) {
+      g_printerr ("Failed to link demux and h264 pads.\n");
+      return;
+    }
+
+    gst_pad_set_active (demux_src_pad, TRUE);
+    gst_pad_set_active (sinkpad, TRUE);
+
+    gst_object_unref (sinkpad);
+  }
+}
+
+static void
+decodebin_child_added (GstChildProxy * child_proxy, GObject * object,
+    gchar * name, gpointer user_data)
+{
+  g_print ("Decodebin child added: %s\n", name);
+  if (g_strrstr (name, "decodebin") == name) {
+    g_signal_connect (G_OBJECT (object), "child-added",
+        G_CALLBACK (decodebin_child_added), user_data);
+  }
+}
+
+static GstElement *
+create_source_bin (guint index, gchar * uri, gboolean is_video)
+{
+  GstElement *bin = NULL, *uri_decode_bin = NULL;
+  gchar bin_name[16] = { };
+
+  g_snprintf (bin_name, 15, "source-bin-%02d", index);
+  /* Create a source GstBin to abstract this bin's content from the rest of the
+   * pipeline */
+  bin = gst_bin_new (bin_name);
+
+  /* Source element for reading from the uri.
+   * We will use decodebin and let it figure out the container format of the
+   * stream and the codec and plug the appropriate demux and decode plugins. */
+  uri_decode_bin = gst_element_factory_make ("uridecodebin", "uri-decode-bin");
+
+  if (!bin || !uri_decode_bin) {
+    g_printerr ("One element in source bin could not be created.\n");
+    return NULL;
+  }
+
+  /* We set the input uri to the source element */
+  g_object_set (G_OBJECT (uri_decode_bin), "uri", uri,
+      "async-handling", 1, NULL);
+
+  /* Connect to the "pad-added" signal of the decodebin which generates a
+   * callback once a new pad for raw data has beed created by the decodebin */
+  g_signal_connect (G_OBJECT (uri_decode_bin), "pad-added",
+      G_CALLBACK (is_video ? cb_newpad_video_server : cb_newpad_audio), bin);
+  g_signal_connect (G_OBJECT (uri_decode_bin), "child-added",
+      G_CALLBACK (decodebin_child_added), bin);
+
+  gst_bin_add (GST_BIN (bin), uri_decode_bin);
+
+  /* We need to create a ghost pad for the source bin which will act as a proxy
+   * for the video decoder src pad. The ghost pad will not have a target right
+   * now. Once the decode bin creates the video decoder and generates the
+   * cb_newpad callback, we will set the ghost pad target to the video decoder
+   * src pad. */
+  if (!gst_element_add_pad (bin, gst_ghost_pad_new_no_target ("src",
+              GST_PAD_SRC))) {
+    g_printerr ("Failed to add ghost pad in source bin\n");
+    return NULL;
+  }
+
+  return bin;
+}
+
+int
+test3_server_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ServerTest3Args *args = &t->args.server_test3;
+  gchar *endptr0 = NULL;
+  if (argc != 5) {
+    g_printerr ("Usage: %s -t 3 -s <addr> <port> "
+        "<audio metadata serialization lib path> <uri>\n", argv[0]);
+    return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll (argv[2], &endptr0, 10);
+  args->libpath = argv[3];
+  args->uri = argv[4];
+
+  if (!g_hostname_is_ip_address (args->addr)) {
+    g_printerr ("Addr specified is not a valid IP address/hostname: %s\n",
+        args->addr);
+    return -1;
+  }
+
+  if ((args->port == 0 && endptr0 == argv[2]) || args->port <= 0) {
+    g_printerr ("Incorrect port specified\n");
+    return -1;
+  }
+
+  if (args->libpath == NULL || args->uri == NULL) {
+    g_printerr ("Invalid library path or URI specified\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+test3_client_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ClientTest3Args *args = &t->args.client_test3;
+  gchar *endptr0 = NULL;
+  if (argc != 5) {
+    g_printerr ("Usage: %s -t 3 -c <addr> <port> "
+        "<audio metadata serialization lib path>  <outputfile>\n", argv[0]);
+    return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll (argv[2], &endptr0, 10);
+  args->libpath = argv[3];
+  args->outfile = argv[4];
+
+  if (!g_hostname_is_ip_address (args->addr)) {
+    g_printerr ("Addr specified is not a valid IP address/hostname: %s\n",
+        args->addr);
+    return -1;
+  }
+
+  if ((args->port == 0 && endptr0 == argv[2]) || args->port <= 0) {
+    g_printerr ("Incorrect port, width or height specified\n");
+    return -1;
+  }
+
+  if (args->libpath == NULL || args->outfile == NULL) {
+    g_printerr ("Invalid library path or output file specified\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+test3_server_setup_pipeline(UcxTest *t)
+{
+  ServerTest3Args *args = &t->args.server_test3;
+  GstElement *source_bin = NULL, *ucxserversink = NULL, *audioconv = NULL,
+      *caps_filter = NULL, *audiores = NULL, *absplit = NULL,
+      *streammux = NULL, *metains = NULL;
+  GstCaps *caps = NULL;
+
+  // Create GStreamer elements
+  streammux = gst_element_factory_make ("nvstreammux", "stream-muxer");
+  audioconv = gst_element_factory_make ("audioconvert", "audio-convert");
+  caps_filter = gst_element_factory_make ("capsfilter", "caps_filter");
+  audiores = gst_element_factory_make ("audioresample", ":audio-resample");
+  absplit = gst_element_factory_make ("audiobuffersplit", "audio-buffer-split");
+  metains = gst_element_factory_make ("nvdsmetainsert", "nvds-meta-insert");
+  ucxserversink = gst_element_factory_make ("nvdsucxserversink", "serversink");
+
+  if (!streammux || !audioconv || !caps_filter || !audiores || !absplit ||
+      !metains || !ucxserversink) {
+    g_printerr ("Failed to create some elements\n");
+    return -1;
+  }
+
+  source_bin = create_source_bin (0, args->uri, FALSE);
+  if (!source_bin) {
+    g_printerr ("Failed to create source bin\n");
+    return -1;
+  }
+
+  caps = gst_caps_new_simple ("audio/x-raw", "format", G_TYPE_STRING, "F32LE",
+      "rate", G_TYPE_INT, 48000, "channels", G_TYPE_INT, 1, "layout",
+      G_TYPE_STRING, "interleaved", NULL);
+  g_object_set (G_OBJECT (caps_filter), "caps", caps, NULL);
+  g_object_set (G_OBJECT (ucxserversink), "addr", args->addr, "port",
+      args->port, "buf-type", 1, NULL);
+  g_object_set (G_OBJECT (streammux), "max-latency", 250000000, NULL);
+  g_object_set (G_OBJECT (streammux), "batch-size", 1, NULL);
+  g_object_set (G_OBJECT (metains), "serialize-lib", args->libpath, NULL);
+
+  gst_bin_add_many (GST_BIN (t->pipeline), streammux, source_bin, audioconv,
+      caps_filter, audiores, absplit, metains, ucxserversink, NULL);
+  GstPad *srcpad, *audsink;
+  srcpad = gst_element_get_static_pad (source_bin, "src");
+  if (!srcpad) {
+    g_printerr ("Failed to get src pad of source bin\n");
+    return -1;
+  }
+  audsink = gst_element_get_static_pad (audioconv, "sink");
+  if (!audsink) {
+    g_printerr ("Audioconvert static sink pad failed\n");
+    return -1;
+  }
+  if (gst_pad_link (srcpad, audsink) != GST_PAD_LINK_OK) {
+    g_printerr ("Failed to link source bin to audioconvert\n");
+    return -1;
+  }
+  gst_object_unref (srcpad);
+  gst_object_unref (audsink);
+
+  if (!gst_element_link_many (audioconv, audiores, caps_filter, absplit,
+      NULL)) {
+    g_printerr ("Failed to link several elements with absplit\n");
+    return -1;
+  }
+
+  GstPad *abssrcpad, *muxsinkpad;
+  gchar pad_name[16] = { };
+  abssrcpad = gst_element_get_static_pad (absplit, "src");
+  if (!abssrcpad) {
+    g_printerr ("Failed to get src pad for audiobuffersplit\n");
+    return -1;
+  }
+  g_snprintf (pad_name, 15, "sink_%u", 0);
+  muxsinkpad = gst_element_request_pad_simple (streammux, pad_name);
+  if (!muxsinkpad) {
+    g_printerr ("Failed to request sink pad for streammux\n");
+    return -1;
+  }
+  if (gst_pad_link (abssrcpad, muxsinkpad) != GST_PAD_LINK_OK) {
+    g_printerr ("Failed to link buffer split src and streammux sink pads\n");
+    return -1;
+  }
+  gst_object_unref (abssrcpad);
+  gst_object_unref (muxsinkpad);
+
+  if (!gst_element_link_many (streammux, metains, ucxserversink, NULL)) {
+    g_printerr ("Failed to link elements with ucxserversink\n");
+    return -1;
+  }
+
+  g_print ("Using URI: %s\n", args->uri);
+  g_print ("Server listening on: %s : %ld\n", args->addr, args->port);
+  return 0;
+}
+
+int
+test3_client_setup_pipeline(UcxTest *t)
+{
+  ClientTest3Args *args = &t->args.client_test3;
+  GstElement *ucxclientsrc = NULL, *caps_filter1 = NULL,
+    *metaext = NULL, *streamdemux = NULL, *audioconv = NULL,
+    *caps_filter2 = NULL, *waveenc = NULL, *filesink = NULL;
+  GstCaps *caps1 = NULL, *caps2 = NULL;
+  GstCapsFeatures *feature = NULL;
+
+  ucxclientsrc = gst_element_factory_make ("nvdsucxclientsrc", "ucxclientsrc");
+  caps_filter1 = gst_element_factory_make ("capsfilter", "caps-filter1");
+  metaext = gst_element_factory_make ("nvdsmetaextract", "nvds-meta-extract");
+  streamdemux = gst_element_factory_make ("nvstreamdemux", "nvdemux");
+  audioconv = gst_element_factory_make ("audioconvert", "audio-convert");
+  caps_filter2 = gst_element_factory_make ("capsfilter", "caps-filter2");
+  waveenc = gst_element_factory_make ("wavenc", "wavenc");
+  filesink = gst_element_factory_make ("filesink", "filesink");
+
+  if (!ucxclientsrc || !caps_filter1 || !metaext || !streamdemux ||
+      !audioconv || !caps_filter2 || !waveenc || !filesink) {
+    g_printerr ("Failed to create some element\n");
+    return -1;
+  }
+
+  /* Set properties */
+  g_object_set (G_OBJECT (ucxclientsrc), "addr", args->addr, "port", args->port,
+      "nvbuf-batch-size", 1, "num-nvbuf", 4, "nvbuf-memory-type", 2,
+      "buf-type", 1, NULL);
+  caps1 = gst_caps_new_simple ("audio/x-raw", "format", G_TYPE_STRING, "F32LE",
+      "rate", G_TYPE_INT, 48000, "channels", G_TYPE_INT, 1, "layout",
+      G_TYPE_STRING, "interleaved", NULL);
+  feature = gst_caps_features_new ("memory:NVMM", NULL);
+  gst_caps_set_features (caps1, 0, feature);
+  g_object_set (G_OBJECT (caps_filter1), "caps", caps1, NULL);
+  g_object_set (G_OBJECT (metaext), "deserialize-lib", args->libpath, NULL);
+  g_object_set (G_OBJECT (filesink), "location", args->outfile, NULL);
+  caps2 = gst_caps_new_simple ("audio/x-raw", "format", G_TYPE_STRING, "S16LE",
+      NULL);
+  g_object_set (G_OBJECT (caps_filter2), "caps", caps2, NULL);
+
+  gst_bin_add_many (GST_BIN (t->pipeline), ucxclientsrc, caps_filter1, metaext,
+      streamdemux, audioconv, caps_filter2, waveenc, filesink, NULL);
+
+  if (!gst_element_link_many (ucxclientsrc, caps_filter1, metaext,
+          streamdemux, NULL)) {
+    g_printerr ("Failed to link some elements till streamdemux\n");
+    return -1;
+  }
+
+  GstPad *demuxsrcpad, *audsinkpad;
+  gchar pad_name[16] = { };
+  g_snprintf (pad_name, 15, "src_%u", 0);
+  demuxsrcpad = gst_element_request_pad_simple (streamdemux, pad_name);
+  if (!demuxsrcpad) {
+    g_printerr ("Failed to request src pad from demux. Exiting.\n");
+    return -1;
+  }
+  audsinkpad = gst_element_get_static_pad (audioconv, "sink");
+  if (!audsinkpad) {
+    g_printerr ("Failed to get sink pad for audio converter\n");
+    return -1;
+  }
+  if (gst_pad_link (demuxsrcpad, audsinkpad) != GST_PAD_LINK_OK) {
+    g_printerr ("Failed to link demux src and audio conv sink pads\n");
+    return -1;
+  }
+  gst_object_unref (demuxsrcpad);
+  gst_object_unref (audsinkpad);
+
+  if (!gst_element_link_many (audioconv, caps_filter2, waveenc, filesink,
+      NULL)) {
+    g_printerr ("Failed to link elements till filesink\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+test2_server_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ServerTest2Args *args = &t->args.server_test2;
+  gchar *endptr0 = NULL, *endptr1 = NULL, *endptr2 = NULL;
+
+  if (argc != 7) {
+    g_printerr ("Usage: %s -t 2 -s <addr> <port> <width> <height> "
+        "<video metadata serialization lib path> <file output path>\n",
+        argv[0]);
+    return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll (argv[2], &endptr0, 10);
+  args->width = g_ascii_strtoll (argv[3], &endptr1, 10);
+  args->height = g_ascii_strtoll (argv[4], &endptr2, 10);
+  args->libpath = argv[5];
+  args->output = argv[6];
+
+  if (!g_hostname_is_ip_address (args->addr)) {
+    g_printerr ("Addr specified is not a valid IP address/hostname: %s\n",
+        args->addr);
+    return -1;
+  }
+
+  if ((args->port == 0 && endptr0 == argv[2]) ||
+      (args->width == 0 && endptr1 == argv[3]) ||
+      (args->height == 0 && endptr2 == argv[4])) {
+    g_printerr ("Incorrect port, width or height specified\n");
+    return -1;
+  }
+
+  if (args->port <= 0 || args->width <= 0 || args->height <= 0) {
+    g_printerr ("Invalid port, width or height\n");
+    return -1;
+  }
+
+  if (args->libpath == NULL || args->output == NULL) {
+    g_printerr ("Invalid custom lib path or output file specified.\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+test2_client_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ClientTest2Args *args = &t->args.client_test2;
+  if (argc != 6) {
+    g_printerr("Usage: %s -t 2 -c <addr> <port> <infer config path> "
+        "<video metadata serialization lib path> <file path>\n", argv[0]);
+    g_printerr("For nvinferserver usage: %s -t 2 -c -i <addr> <port> "
+    "<nvinferserver config path> <video metadata serialization lib path> "
+    "<file path>\n", argv[0]);
+    return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll(argv[2], NULL, 10);
+  args->inferpath = argv[3];
+  args->libpath = argv[4];
+  args->uri = argv[5];
+
+  if (!g_hostname_is_ip_address(args->addr)) {
+    g_printerr("Addr specified is not a valid IP address/hostname: %s\n",
+        args->addr);
+    return -1;
+  }
+
+  if (args->port <= 0) {
+    g_printerr("Incorrect port specified\n");
+    return -1;
+  }
+
+  if (args->inferpath == NULL || args->libpath == NULL || args->uri == NULL) {
+    g_printerr("Invalid path for infer config or custom lib or "
+        "file specified\n");
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+test2_server_setup_pipeline(UcxTest *t)
+{
+  ServerTest2Args *args = &t->args.server_test2;
+  GstElement *ucxserversrc = NULL, *caps_filter = NULL, *nvvidconv = NULL,
+      *nvmetaext = NULL, *nvosd = NULL, *nvvidconv2 = NULL, *nvenc = NULL,
+      *h264parse = NULL, *qtmux = NULL, *filesink = NULL;
+  GstCaps *caps = NULL;
+
+  // Create GStreamer elements
+  nvvidconv = gst_element_factory_make ("nvvideoconvert", "nvvideo-converter");
+  caps_filter = gst_element_factory_make ("capsfilter", "caps_filter");
+  ucxserversrc = gst_element_factory_make ("nvdsucxserversrc", "serversrc");
+  nvmetaext = gst_element_factory_make ("nvdsmetaextract", "nvds-meta-extract");
+  nvosd = gst_element_factory_make ("nvdsosd", "nvosd");
+  nvvidconv2 = gst_element_factory_make ("nvvideoconvert", "nvvideo-converter2");
+  nvenc = gst_element_factory_make ("nvv4l2h264enc", "nvh264enc");
+  h264parse = gst_element_factory_make ("h264parse", "h264-parse");
+  qtmux = gst_element_factory_make ("qtmux", "qt-mux");
+  filesink = gst_element_factory_make ("filesink", "file-sink");
+
+  if (!nvvidconv || !caps_filter || !ucxserversrc || !nvmetaext ||
+      !nvosd || !nvvidconv2 || !nvenc || !h264parse || !qtmux || !filesink) {
+    g_printerr ("Failed to create some elements\n");
+    return -1;
+  }
+
+  caps = gst_caps_new_simple ("video/x-raw", "format", G_TYPE_STRING, "NV12",
+      "width", G_TYPE_INT, args->width, "height", G_TYPE_INT, args->height,
+      "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
+  gst_caps_set_features (caps, 0, gst_caps_features_new ("memory:NVMM", NULL));
+  g_object_set (G_OBJECT (caps_filter), "caps", caps, NULL);
+  g_object_set (G_OBJECT (nvmetaext), "deserialize-lib", args->libpath, NULL);
+  g_object_set (G_OBJECT (ucxserversrc), "addr", args->addr, "port",
+      args->port, "nvbuf-memory-type", 2, "num-nvbuf", 8, "buf-type", 0, NULL);
+  g_object_set (G_OBJECT (filesink), "location", args->output, NULL);
+
+  gst_bin_add_many (GST_BIN (t->pipeline), ucxserversrc, caps_filter, nvvidconv,
+      nvmetaext, nvosd, nvvidconv2, nvenc, h264parse, qtmux, filesink, NULL);
+
+  if (!gst_element_link_many (ucxserversrc, caps_filter, nvvidconv,
+      nvmetaext, nvosd, nvvidconv2, nvenc, h264parse, qtmux,
+      filesink, NULL)) {
+    g_printerr ("Failed to link some elements\n");
+    return -1;
+  }
+  g_print ("Server listening on: %s : %ld\n", args->addr, args->port);
+
+  return 0;
+}
+
+int
+test2_client_setup_pipeline(UcxTest *t)
+{
+  ClientTest2Args *args = &t->args.client_test2;
+  GstElement *filesrc = NULL, *streammux = NULL,
+      *ucxclientsink = NULL, *qtdemux = NULL, *h264parse = NULL,
+      *nvdecode = NULL, *nvvidconv = NULL, *pgie = NULL, *nvmetains = NULL,
+      *queue1 = NULL;
+
+  filesrc = gst_element_factory_make("filesrc", "file-src");
+  qtdemux = gst_element_factory_make("qtdemux", "qt-demux");
+  h264parse = gst_element_factory_make("h264parse", "h264-parse");
+  nvdecode = gst_element_factory_make("nvv4l2decoder", "nvv-4l2decoder");
+  nvvidconv = gst_element_factory_make("nvvideoconvert", "nvvideo-converter");
+  pgie = gst_element_factory_make(t->is_nvinfer_server ?
+      NVINFERSERVER_PLUGIN : NVINFER_PLUGIN, "nv-infer");
+  nvmetains = gst_element_factory_make("nvdsmetainsert", "nvds-meta-insert");
+  ucxclientsink = gst_element_factory_make("nvdsucxclientsink", "clientsink");
+  queue1 = gst_element_factory_make("queue", "queue1");
+  streammux = gst_element_factory_make ("nvstreammux", "stream-muxer");
+
+  // Error check
+  if (!streammux || !filesrc || !qtdemux || !h264parse || !nvdecode ||
+      !nvvidconv || !pgie || !nvmetains || !ucxclientsink || !queue1) {
+    g_printerr("Failed to create some elements\n");
+    return -1;
+  }
+
+  // Set the properties for the elements
+  g_object_set(G_OBJECT(filesrc), "location", args->uri, NULL);
+  g_object_set(G_OBJECT(ucxclientsink), "addr", args->addr, "port", args->port,
+      "buf-type", 0, NULL);
+  g_object_set(G_OBJECT(pgie), "config-file-path", args->inferpath, NULL);
+  g_object_set(G_OBJECT(nvmetains), "serialize-lib", args->libpath, NULL);
+  g_object_set (G_OBJECT (streammux), "batch-size", 1, NULL);
+
+  // Add elements to the pipeline and link them
+  gst_bin_add_many(GST_BIN(t->pipeline), filesrc, qtdemux, h264parse, nvdecode,
+      streammux, nvvidconv, pgie, nvmetains, ucxclientsink, NULL);
+
+  g_signal_connect(G_OBJECT(qtdemux), "pad-added",
+      G_CALLBACK(cb_newpad_client), h264parse);
+  if (!gst_element_link(filesrc, qtdemux)) {
+    g_printerr("Failed to link filesrc and qtdemux\n");
+    return -1;
+  }
+  if (!gst_element_link(h264parse, nvdecode)) {
+    g_printerr("Failed to link h264parse and nv4l2decode\n");
+    return -1;
+  }
+
+  if (!gst_element_link_many(streammux, nvvidconv, pgie, nvmetains,
+      ucxclientsink, NULL)) {
+    g_printerr("Failed to link several elements including clientsink\n");
+    return -1;
+  }
+
+  GstPad *srcpad, *muxsinkpad;
+  gchar pad_name[16] = { };
+  srcpad = gst_element_get_static_pad(nvdecode, "src");
+  if (!srcpad) {
+    g_printerr("Failed to get src pad for decoder\n");
+    return -1;
+  }
+  g_snprintf(pad_name, 15, "sink_%u", 0);
+  muxsinkpad = gst_element_request_pad_simple (streammux, pad_name);
+  if (!muxsinkpad) {
+    g_printerr("Failed to request sink pad for streammux\n");
+    return -1;
+  }
+  if (gst_pad_link(srcpad, muxsinkpad) != GST_PAD_LINK_OK) {
+    g_printerr("Failed to link decode src and streammux sink pads\n");
+    return -1;
+  }
+  gst_object_unref(srcpad);
+  gst_object_unref(muxsinkpad);
+
+  return 0;
+}
+
+int
+test1_server_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ServerTest1Args *args = &t->args.server_test1;
+  gchar *endptr0 = NULL, *endptr1 = NULL, *endptr2 = NULL;
+
+  /* Check input arguments */
+  if (argc != 6) {
+      g_printerr("Usage: %s -t 1 -s <addr> <port> <width> <height> <uri>\n",
+          argv[0]);
+      return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll(argv[2], &endptr0, 10);
+  args->width = g_ascii_strtoll(argv[3], &endptr1, 10);
+  args->height = g_ascii_strtoll(argv[4], &endptr2, 10);
+  args->uri = argv[5];
+
+  if (!g_hostname_is_ip_address(args->addr)) {
+      g_printerr("Address specified is not a valid IP address/hostname: %s\n",
+          args->addr);
+      return -1;
+  }
+
+  if ((args->port == 0 && endptr0 == argv[2]) ||
+      (args->width == 0 && endptr1 == argv[3]) ||
+      (args->height == 0 && endptr2 == argv[4])) {
+      g_printerr("Incorrect port, width or height specified\n");
+      return -1;
+  }
+
+  if (args->port <= 0 || args->width <= 0 || args->height <= 0) {
+      g_printerr("Invalid port, width or height\n");
+      return -1;
+  }
+
+  if (args->uri == NULL) {
+      g_printerr("Invalid URI\n");
+      return -1;
+  }
+
+  return 0;
+}
+
+int
+test1_client_parse_args(int argc, char *argv[], UcxTest *t)
+{
+  ClientTest1Args *args = &t->args.client_test1;
+  gchar *endptr0 = NULL, *endptr1 = NULL, *endptr2 = NULL;
+
+  if (argc != 6) {
+    g_printerr("Usage: %s -t 1 -c <addr> <port> <width> <height> <outputfile>\n",
+       argv[0]);
+    return -1;
+  }
+
+  args->addr = argv[1];
+  args->port = g_ascii_strtoll(argv[2], &endptr0, 10);
+  args->width = g_ascii_strtoll(argv[3], &endptr1, 10);
+  args->height = g_ascii_strtoll(argv[4], &endptr2, 10);
+  args->outfile = argv[5];
+
+  if (!g_hostname_is_ip_address(args->addr)) {
+    g_printerr("Addr specified is not a valid IP address/hostname: %s\n",
+        args->addr);
+    return -1;
+  }
+
+  if ((args->port == 0 && endptr0 == argv[2]) ||
+      (args->width == 0 && endptr1 == argv[3]) ||
+      (args->height == 0 && endptr2 == argv[4])) {
+    g_printerr("Incorrect port, width, or height specified\n");
+    return -1;
+  }
+
+  if (args->port <= 0 || args->width <= 0 || args->height <= 0) {
+    g_printerr("Invalid port, width or height\n");
+    return -1;
+  }
+
+  if (args->outfile == NULL) {
+    g_printerr("Invalid output file\n");
+    return -1;
+  }
+
+  return 0;  // Indicates success
+}
+
+int
+test1_server_setup_pipeline(UcxTest *t)
+{
+  ServerTest1Args *args = &t->args.server_test1;
+  GstElement *ucxserversink = NULL, *nvvidconv = NULL, *caps_filter = NULL,
+     *queue = NULL;
+  GstCaps *caps = NULL;
+  GstCapsFeatures *feature = NULL;
+  GstPad *srcpad, *qsink;
+
+  GstElement *source_bin = create_source_bin(0, args->uri, TRUE);
+  if (!source_bin) {
+    g_printerr("Failed to create source bin\n");
+    return -1;
+  }
+
+  gst_bin_add(GST_BIN(t->pipeline), source_bin);
+
+  /* Create the remaining elements. */
+  nvvidconv = gst_element_factory_make("nvvideoconvert", "nvvideo-converter");
+  queue = gst_element_factory_make("queue", "queue");
+  caps_filter = gst_element_factory_make("capsfilter", "caps_filter");
+  ucxserversink = gst_element_factory_make("nvdsucxserversink", "serversink");
+
+  if (!nvvidconv || !queue || !caps_filter || !ucxserversink) {
+      g_printerr("Failed to create video converter or caps element or ucx\n");
+      return -1;
+  }
+
+  /* Set parameters */
+  caps = gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "NV12",
+      "width", G_TYPE_INT, args->width, "height", G_TYPE_INT, args->height,
+      "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
+  feature = gst_caps_features_new("memory:NVMM", NULL);
+  gst_caps_set_features(caps, 0, feature);
+  g_object_set(G_OBJECT(caps_filter), "caps", caps, NULL);
+  g_object_set(G_OBJECT(ucxserversink), "addr", args->addr, "port", args->port,
+      "buf-type", 0, NULL);
+
+  gst_bin_add_many(GST_BIN(t->pipeline), queue, nvvidconv, caps_filter,
+      ucxserversink, NULL);
+
+  srcpad = gst_element_get_static_pad(source_bin, "src");
+  if (!srcpad) {
+    g_printerr("Failed to get src pad of source bin\n");
+    return -1;
+  }
+  qsink = gst_element_get_static_pad(queue, "sink");
+  if (!qsink) {
+    g_printerr("Queue static sink pad failed\n");
+    return -1;
+  }
+  if (gst_pad_link(srcpad, qsink) != GST_PAD_LINK_OK) {
+    g_printerr("Failed to link source bin to queue\n");
+    return -1;
+  }
+  gst_object_unref(srcpad);
+  gst_object_unref(qsink);
+
+  if (!gst_element_link_many(queue, nvvidconv, caps_filter, ucxserversink, NULL)) {
+      g_printerr("Failed to link several elements\n");
+      return -1;
+  }
+
+  g_print ("Using URI: %s\n", args->uri);
+  g_print ("Server listening on: %s : %ld\n", args->addr, args->port);
+  return 0;
+}
+
+int
+test1_client_setup_pipeline(UcxTest *t)
+{
+  ClientTest1Args *args = &t->args.client_test1;
+  GstElement *ucxclientsrc = NULL, *nvvidconv = NULL, *caps_filter = NULL,
+      *filesink = NULL, *queue1 = NULL, *h264enc = NULL,
+      *h264parser = NULL, *qtmux = NULL;
+  GstCaps *caps = NULL;
+  GstCapsFeatures *feature = NULL;
+
+  ucxclientsrc = gst_element_factory_make ("nvdsucxclientsrc", "ucxclientsrc");
+  caps_filter = gst_element_factory_make ("capsfilter", "caps_filter");
+  queue1 = gst_element_factory_make ("queue", "queue1");
+  nvvidconv = gst_element_factory_make ("nvvideoconvert", "nvvideo-converter");
+  h264enc = gst_element_factory_make ("nvv4l2h264enc", "h264-hw-enc");
+  h264parser = gst_element_factory_make ("h264parse", "h264-parse");
+  qtmux = gst_element_factory_make ("qtmux", "qt-mux");
+  filesink = gst_element_factory_make ("filesink", "file-sink");
+
+  if (!ucxclientsrc || !caps_filter || !queue1 || !nvvidconv || !h264enc ||
+      !h264parser || !qtmux || !filesink) {
+    g_printerr ("One pipeline element could not be created\n");
+    return -1;
+  }
+
+  /* Set ucxclientsrc properties */
+  g_object_set (G_OBJECT (ucxclientsrc), "addr", args->addr, "port",
+      args->port,"nvbuf-batch-size", 1, "num-nvbuf", 4, "nvbuf-memory-type",
+      2, NULL);
+  caps = gst_caps_new_simple ("video/x-raw", "format", G_TYPE_STRING, "NV12",
+      "width", G_TYPE_INT, args->width, "height", G_TYPE_INT, args->height,
+      "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
+  feature = gst_caps_features_new ("memory:NVMM", NULL);
+  gst_caps_set_features (caps, 0, feature);
+  g_object_set (G_OBJECT (caps_filter), "caps", caps, NULL);
+
+  /* Set filesink properties */
+  g_object_set (G_OBJECT (filesink), "location", args->outfile, "async", 0,
+      "sync", 1, "qos", 0, NULL);
+
+  gst_bin_add_many (GST_BIN (t->pipeline), ucxclientsrc, caps_filter,
+      nvvidconv, queue1, h264enc, h264parser, qtmux, filesink, NULL);
+
+  if (!gst_element_link_many (ucxclientsrc, caps_filter, queue1, nvvidconv,
+      h264enc, h264parser, qtmux, filesink, NULL)) {
+    g_printerr ("Failed to link several elements\n");
+    return -1;
+  }
+  g_print ("Now saving stream to: %s\n", args->outfile);
+
+  return 0;  // Indicates success
+}
+
+void
+run_pipeline (UcxTest *t) {
+  GstBus *bus = NULL;
+  guint bus_watch_id;
+
+    /* we add a message handler */
+  bus = gst_pipeline_get_bus(GST_PIPELINE(t->pipeline));
+  bus_watch_id = gst_bus_add_watch(bus, bus_call, t->loop);
+  gst_object_unref(bus);
+
+  gst_element_set_state (t->pipeline, GST_STATE_PLAYING);
+
+  /* Wait till pipeline encounters an error or EOS */
+  g_print ("Running...\n");
+  g_main_loop_run (t->loop);
+
+  /* Out of the main loop, clean up nicely */
+  g_print ("Returned, stopping playback\n");
+  gst_element_set_state (t->pipeline, GST_STATE_NULL);
+  g_print ("Deleting pipeline\n");
+  gst_object_unref (GST_OBJECT (t->pipeline));
+  g_source_remove (bus_watch_id);
+  g_main_loop_unref (t->loop);
+  return;
+}
+
+
+int main (int argc, char *argv[])
+{
+  UcxTest t = {0};
+  t.role = INIT;
+  t.test_id = -1;
+  t.is_nvinfer_server = FALSE;
+  struct cudaDeviceProp prop;
+  int current_device = -1;
+  char *new_argv[argc];
+  int new_argc = 0;
+
+  for (int i = 0; i < argc; i++) {
+    if (g_strcmp0(argv[i], "-t") == 0 && i + 1 < argc) {
+      t.test_id = atoi(argv[++i]);
+    } else if (g_strcmp0(argv[i], "-s") == 0) {
+        t.role = SERVER;
+    } else if (g_strcmp0(argv[i], "-c") == 0) {
+        t.role = CLIENT;
+    } else if (g_strcmp0(argv[i], "-i") == 0) {
+        t.is_nvinfer_server = TRUE;
+    } else {
+      new_argv[new_argc++] = argv[i];
+    }
+  }
+
+  if (t.test_id < 1 || t.test_id > sizeof(testOperations) / sizeof(TestOps)) {
+    g_printerr ("Invalid test case: %d use -t <1-3>\n", t.test_id);
+    return -1;
+  }
+
+  OperationFunctions *ops;
+  if (t.role == SERVER) {
+    ops = &testOperations[t.test_id - 1].server;
+  } else if (t.role == CLIENT) {
+    ops = &testOperations[t.test_id - 1].client;
+  } else {
+    g_printerr ("Invalid arguments: use -c for client and -s for server\n");
+    return -1;
+  }
+
+  cudaGetDevice(&current_device);
+  cudaGetDeviceProperties(&prop, current_device);
+
+  if (ops->parse_args(new_argc, new_argv, &t) != 0) {
+    return -1;
+  }
+
+  /* Standard GStreamer initialization */
+  gst_init (&argc, &argv);
+  t.loop = g_main_loop_new(NULL, FALSE);
+    if (t.role == SERVER) {
+    t.pipeline = gst_pipeline_new("ds-ucx-server-pipeline");
+  } else if (t.role == CLIENT) {
+    t.pipeline = gst_pipeline_new("ds-ucx-client-pipeline");
+  }
+  if (!t.pipeline) {
+    g_printerr("Failed to create pipeline\n");
+    return -1;
+  }
+
+  if (ops->setup_pipeline(&t) != 0) {
+    return -1;
+  }
+
+  run_pipeline(&t);
+
+  return 0;
+
+}
+

--- a/src/apps/sample_apps/deepstream-ucx-test/deepstream_ucx_test_app.h
+++ b/src/apps/sample_apps/deepstream-ucx-test/deepstream_ucx_test_app.h
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+#ifndef DEEPSTREAM_UCX_TEST_APP_H
+#define DEEPSTREAM_UCX_TEST_APP_H
+
+#include <glib.h>
+#include <stdio.h>
+
+/* Constants definitions */
+#define MUXER_OUTPUT_WIDTH 1920
+#define MUXER_OUTPUT_HEIGHT 1080
+#define MUXER_BATCH_TIMEOUT_USEC 40000
+#define GST_CAPS_FEATURES_NVMM "memory:NVMM"
+#define NVINFER_PLUGIN "nvinfer"
+#define NVINFERSERVER_PLUGIN "nvinferserver"
+
+
+/* Server Arguments */
+
+typedef struct {
+  gchar *addr;
+  gint64 port;
+  gint64 width;
+  gint64 height;
+  gchar *uri;
+} ServerTest1Args;
+
+typedef struct {
+  gchar *addr;
+  gint64 port;
+  gint64 width;
+  gint64 height;
+  gchar *libpath;
+  gchar *output;
+} ServerTest2Args;
+
+typedef struct {
+  gchar *addr;
+  gint64 port;
+  gchar *libpath;
+  gchar *uri;
+} ServerTest3Args;
+
+/* Client Arguments */
+
+typedef struct {
+    gchar *addr;
+    gint64 port;
+    gint64 width;
+    gint64 height;
+    gchar *outfile;
+} ClientTest1Args;
+
+typedef struct {
+    gchar *addr;
+    gint64 port;
+    gchar *inferpath;
+    gchar *libpath;
+    gchar *uri;
+} ClientTest2Args;
+
+typedef struct {
+    gchar *addr;
+    gint64 port;
+    gchar *libpath;
+    gchar *outfile;
+} ClientTest3Args;
+
+/* Common Structs */
+
+typedef enum {
+  SERVER,
+  CLIENT,
+  INIT
+} Role;
+
+typedef struct {
+  int test_id;
+  GMainLoop *loop;
+  GstElement *pipeline;
+  Role role;
+  gboolean is_nvinfer_server;
+
+  union {
+    ServerTest1Args server_test1;
+    ServerTest2Args server_test2;
+    ServerTest3Args server_test3;
+    ClientTest1Args client_test1;
+    ClientTest2Args client_test2;
+    ClientTest3Args client_test3;
+  } args;
+} UcxTest;
+
+/* Function prototypes */
+
+// Test 1
+int test1_client_parse_args(int argc, char *argv[], UcxTest *t);
+int test1_client_setup_pipeline(UcxTest *t);
+
+int test1_server_parse_args(int argc, char *argv[], UcxTest *t);
+int test1_server_setup_pipeline(UcxTest *t);
+
+// Test 2
+int test2_client_parse_args(int argc, char *argv[], UcxTest *t);
+int test2_client_setup_pipeline(UcxTest *t);
+
+int test2_server_parse_args(int argc, char *argv[], UcxTest *t);
+int test2_server_setup_pipeline(UcxTest *t);
+
+// Test 3
+int test3_client_parse_args(int argc, char *argv[], UcxTest *t);
+int test3_client_setup_pipeline(UcxTest *t);
+
+int test3_server_parse_args(int argc, char *argv[], UcxTest *t);
+int test3_server_setup_pipeline(UcxTest *t);
+
+
+typedef struct {
+  int (*parse_args)(int argc, char *argv[], UcxTest *t);
+  int (*setup_pipeline)(UcxTest *t);
+} OperationFunctions;
+
+typedef struct {
+  OperationFunctions client;
+  OperationFunctions server;
+} TestOps;
+
+TestOps testOperations[] = {
+  {
+    {test1_client_parse_args, test1_client_setup_pipeline},
+    {test1_server_parse_args, test1_server_setup_pipeline}
+  },
+  {
+    {test2_client_parse_args, test2_client_setup_pipeline},
+    {test2_server_parse_args, test2_server_setup_pipeline}
+  },
+  {
+    {test3_client_parse_args, test3_client_setup_pipeline},
+    {test3_server_parse_args, test3_server_setup_pipeline}
+  }
+};
+
+
+
+#endif // DEEPSTREAM_UCX_TEST_APP_H


### PR DESCRIPTION
## Summary
Migrates the UCX sample app and dual-license update from the internal mono-repo (DeepStreamSDK MR !94) into the OSS repo.

- Add `deepstream-ucx-test` sample app under `src/apps/sample_apps/` (x86-only; built and validated against DS 9.0 on x86)
- Guard `build/build.sh` sample-apps loop to skip `deepstream-ucx-test` on aarch64 and SBSA (no UCX support shipped for non-x86)
- Replace Apache-2.0 `LICENSE` with the **CC-BY-4.0 AND Apache-2.0** dual-license text (byte-identical to [NVIDIA-AI-IOT/DeepStream_Coding_Agent/LICENSE](https://github.com/NVIDIA-AI-IOT/DeepStream_Coding_Agent/blob/main/LICENSE))
- Root `README.md`: update `# License` section to reflect the dual license; restructure Overview's Tools/Skills paragraph into bold subheads with bullets; move the "pipelines combine..." sentence into the top DeepStream section; tighten Requirements lead-in; fix SBSA link display text (`BUILD.md` → `build/BUILD.md`)
- `src/README.md`: move `deepstream-ucx-test` from Deprecated Components into the Platform-Specific Components table

## Commits
- `f17bb41` feat: add x86-only deepstream-ucx-test sample app and dual-license LICENSE
- `2021dbf` docs(README): update License section to CC-BY-4.0 AND Apache-2.0
- `393f745` docs(src/README): list deepstream-ucx-test as platform-specific, drop from deprecated
- `1391ddf` docs(README): restructure Overview and tighten Requirements wording

## Notes
- Per-file SPDX headers in the UCX sources are intentionally left as `LicenseRef-NvidiaProprietary`, matching the convention currently used by other sample apps in this repo (e.g. `deepstream-app`). They can be migrated to Apache-2.0 in a follow-up sweep.

## Test plan
- [x] x86 build of `deepstream-ucx-test-app` succeeds; binary installs to `/opt/nvidia/deepstream/deepstream-9.0/bin/`; `ldd` reports no missing libs
- [ ] aarch64 build (Jetson) confirms `Skipping deepstream-ucx-test on aarch64 (x86 only)` log line and no build attempt
- [ ] SBSA build confirms the same skip behavior
- [ ] Runtime smoke of `deepstream-ucx-test-app` against a UCX-enabled pipeline (reviewer's discretion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)