### PR TITLE
docs(README): restore lost deepstream_dockers bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Summary of benchmarks; for detailed performance numbers and hardware used, refer
 ## Releases & Roadmap
 - Releases/Changelog: <link>
 - **[`deepstream_libraries`](https://github.com/NVIDIA-AI-IOT/deepstream_libraries)** is not currently part of this GitHub OSS repository. For details and usage, refer to the [DeepStream Libraries documentation](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Libraries.html).
+- [deepstream_dockers](https://github.com/NVIDIA-AI-IOT/deepstream_dockers/) is not currently part of this GitHub OSS repository. For details and usage, refer to the [Open Source Dockerfiles Guide](https://github.com/NVIDIA-AI-IOT/deepstream_dockers/blob/main/README.md)
   
 # Contribution Guidelines
 This project is currently not accepting contributions.


### PR DESCRIPTION
## Summary

PR #12 (\"Add deepstream_dockers repo reference to Releases & Roadmap section\") was merged into `main` as `4066c029`, but the new bullet never actually landed.

**Root cause:** While PR #12 was open, PR #13 merged first, so its source branch fell behind `main`. The follow-up merge of `main` into `update_readme` (commit `7ae7015`, \"Merge branch 'main' into update_readme\") had a conflict in `README.md` around the same lines, and the conflict resolution silently dropped the `- [deepstream_dockers](...)` bullet from the resolved tree.

| Commit | `deepstream_dockers` bullet in README? |
|---|---|
| `38b7783` (original PR #12 change) | ✅ Yes |
| `7ae7015` (post conflict-resolution merge) | ❌ No |
| `4066c029` (final merge into main) | ❌ No |

`git diff c854f00 4066c029 -- README.md` was empty — so although the PR was \"merged\", the content change was effectively a no-op.

## Fix

Re-add the bullet under the existing `## Releases & Roadmap` section, alongside the `deepstream_libraries` bullet that already lives there. Uses the same wording, link, and section as the original PR #12 change.

## Test plan

- [ ] GitHub render preview confirms the bullet shows up under `## Releases & Roadmap`
- [ ] Both links (`deepstream_dockers` repo + Open Source Dockerfiles Guide) resolve