### PR TITLE
docs(build/BUILD): restore SBSA baremetal exception, fix OSS clone URL

### DIFF
--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -112,11 +112,20 @@ Build and validation must be done **inside the Docker container**.
    apt-get update && apt-get install -y git cmake make build-essential
    ```
 
-3. Clone the mono-repo:
+3. Clone the repository (with submodules):
    ```bash
-   git clone https://gitlab-master.nvidia.com/DeepStreamSDK/deepstream -b main deepstream
-   cd deepstream
+   git clone --recurse-submodules https://github.com/NVIDIA/DeepStream.git
+   cd DeepStream
    ```
+
+#### Components that must be built and run on the host (baremetal)
+
+The SBSA Docker flow above does **not** cover every component. The following components are not validated inside the container and must instead be built and run from a separate clone of the repository on the baremetal SBSA / DGX Spark host:
+
+- `tools/inference_builder` — see [`tools/inference_builder/README.md`](../tools/inference_builder/README.md)
+- `src/apps/reference_apps/deepstream-tracker-3d-multi-view` — see [`src/apps/reference_apps/deepstream-tracker-3d-multi-view/README.md`](../src/apps/reference_apps/deepstream-tracker-3d-multi-view/README.md)
+
+Clone the repository a second time on the host (outside any container) and follow each component's own README for its build and run steps.
 
 ---
 


### PR DESCRIPTION
## Summary

- Restore the **"Components that must be built and run on the host (baremetal)"** subsection in `build/BUILD.md` (lost during the OSS sync that landed via PR #7).
- Both bullets are listed: `tools/inference_builder` and `src/apps/reference_apps/deepstream-tracker-3d-multi-view`. Both exist in this repo (IB as a submodule via PR #9; tracker-3d-multi-view under `src/apps/reference_apps/`).
- Fix step 3 of the SBSA flow: the clone URL still pointed at the internal `gitlab-master.nvidia.com/DeepStreamSDK/deepstream` mono-repo. Replace with `https://github.com/NVIDIA/DeepStream.git` and add `--recurse-submodules` so `tools/inference_builder` is populated.

## Why IB needs the baremetal exception

`tools/inference_builder` is a code-generation tool that produces a Python package and Dockerfiles, then uses `docker buildx` (with the NVIDIA Container Toolkit, `nvidia` runtime, `docker` group membership) to build target inference microservice container images — including the `Dockerfile.dgxspark` / `nvcr.io/nvidia/deepstream:9.0-triton-sbsa-dgx-spark` flow documented in the submodule's `doc/platform-guide.md`. This workflow needs host Docker daemon access and is not validated inside the DS SBSA build container, so IB must be built and run from a separate clone on the baremetal SBSA / DGX Spark host.

## Test plan

- [ ] `build/BUILD.md` renders cleanly on GitHub — both bullets present, links resolve.
- [ ] `tools/inference_builder/README.md` link points to the submodule's README.
- [ ] `src/apps/reference_apps/deepstream-tracker-3d-multi-view/README.md` link resolves in-tree.
- [ ] Step 3 clone URL is the OSS GitHub URL with `--recurse-submodules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)