### PR TITLE
fix(nvds_msgapi,nvmsgbroker): correct DS_INC in Makefile.test

### DIFF
--- a/src/utils/nvds_msgapi/amqp_protocol_adaptor/Makefile.test
+++ b/src/utils/nvds_msgapi/amqp_protocol_adaptor/Makefile.test
@@ -13,7 +13,7 @@
 # this  Makefile is to be used to build the test application to exercise the sample amqp protocol adaptor
 CXX:=g++
 NVDS_VERSION?=9.0
-DS_INC:= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/sources/includes/
+DS_INC:= ../../../../includes
 
 DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
 

--- a/src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/Makefile.test
+++ b/src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/Makefile.test
@@ -12,7 +12,7 @@
 #######################################################################################################
 # this  Makefile is to be used to build the test application to exercise the sample azure device client protocol adaptor
 CXX:=g++
-DS_INC:= ../../../includes
+DS_INC:= ../../../../../includes
 
 NVDS_VERSION?=9.0
 

--- a/src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/Makefile.test
+++ b/src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/Makefile.test
@@ -12,7 +12,7 @@
 #######################################################################################################
 # this  Makefile is to be used to build the test application to exercise the sample azure module client protocol adaptor
 CXX:=g++
-DS_INC:= ../../../includes
+DS_INC:= ../../../../../includes
 
 NVDS_VERSION?=9.0
 

--- a/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile.test
+++ b/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile.test
@@ -12,7 +12,7 @@
 # this  Makefile is to be used to build the test application to exercise the sample_proto protocol adaptor
 CXX:=g++
 NVDS_VERSION?=9.0
-DS_INC:= ../../includes
+DS_INC:= ../../../../includes
 DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
 
 SYNC_SEND_BIN:= test_kafka_proto_sync

--- a/src/utils/nvds_msgapi/mqtt_protocol_adaptor/Makefile.test
+++ b/src/utils/nvds_msgapi/mqtt_protocol_adaptor/Makefile.test
@@ -30,7 +30,7 @@
 # this  Makefile is to be used to build the test application to exercise the sample mqtt protocol adaptor
 CXX:=g++
 NVDS_VERSION?=9.0
-DS_INC:= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/sources/includes/
+DS_INC:= ../../../../includes
 
 DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
 

--- a/src/utils/nvds_msgapi/redis_protocol_adaptor/Makefile.test
+++ b/src/utils/nvds_msgapi/redis_protocol_adaptor/Makefile.test
@@ -12,7 +12,7 @@
 #######################################################################################################
 # this  Makefile is to be used to build the test application to exercise the sample redis protocol adaptor
 CXX:=g++
-DS_INC:= ../../includes
+DS_INC:= ../../../../includes
 
 NVDS_VERSION?=9.0
 

--- a/src/utils/nvmsgbroker/Makefile.test
+++ b/src/utils/nvmsgbroker/Makefile.test
@@ -13,7 +13,7 @@
 # this  Makefile is to be used to build the test application to exercise the sample_proto protocol adaptor
 CXX:=g++
 NVDS_VERSION?=9.0
-DS_INC:= ../../includes
+DS_INC:= ../../../includes
 DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
 
 TEST_BIN:= test_msgbroker


### PR DESCRIPTION
## Summary

The `Makefile.test` files for `nvmsgbroker` and all six `nvds_msgapi` protocol adaptors had stale `DS_INC` paths that don't resolve to the repo-root `includes/` directory in the current `src/utils/...` layout. Each non-test `Makefile` next to these already uses the correct value — the test ones were just never updated.

| File | Before | After |
|---|---|---|
| `src/utils/nvmsgbroker/Makefile.test` | `../../includes` → `src/includes/` ❌ | `../../../includes` → `includes/` |
| `src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile.test` | `../../includes` ❌ | `../../../../includes` |
| `src/utils/nvds_msgapi/redis_protocol_adaptor/Makefile.test` | `../../includes` ❌ | `../../../../includes` |
| `src/utils/nvds_msgapi/amqp_protocol_adaptor/Makefile.test` | `/opt/.../sources/includes/` (only resolves if DS deb is installed) | `../../../../includes` |
| `src/utils/nvds_msgapi/mqtt_protocol_adaptor/Makefile.test` | same as amqp | `../../../../includes` |
| `src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/Makefile.test` | `../../../includes` ❌ | `../../../../../includes` |
| `src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/Makefile.test` | `../../../includes` ❌ | `../../../../../includes` |

Net diff: **7 files, +7 / -7**.

## Reproducer (before fix)

```
sudo apt-get install git-lfs
git clone https://github.com/NVIDIA/DeepStream/ && cd DeepStream
sudo bash build/build.sh
# follow kafka_protocol_adaptor README to set up kafka
cd src/utils/nvds_msgapi/kafka_protocol_adaptor
sudo make
sudo make -f Makefile.test
# -> test_kafka_proto_sync.cpp:17:10: fatal error: nvds_msgapi.h: No such file or directory
```

All six adaptors and `nvmsgbroker` fail the same way (relative-path variants resolve to `src/{,utils/}includes/` which doesn't exist; amqp/mqtt variants resolve to `/opt/nvidia/deepstream/deepstream-9.0/sources/includes/` which only exists when the DS deb has been installed).

## Test plan

- [ ] In a fresh OSS clone after `sudo bash build/build.sh`, run `sudo make -f Makefile.test` inside each of the 7 directories and confirm the test binaries link.
- [ ] Smoke-run `test_kafka_proto_sync` (or any adaptor test) against a kafka broker per `kafka_protocol_adaptor/README` to confirm no runtime regression.

## Notes

- Bug is present in the GitLab mono-repo too (same byte-for-byte `Makefile.test` content); it just hadn't surfaced there because the mono-repo flow doesn't typically exercise `make -f Makefile.test` from a fresh clone.
- Production `Makefile`s in these directories were not touched — they already use the correct paths.
- Separate non-blocking hygiene issues (dead `-I` flags in `nvds_analytics/Makefile`, `deepstream-dynamicsrcbin-test/Makefile`, 2× `ds3d` `CUFLAGS`, and the stale `Makefile.ds` doc snippet) were verified to be harmless and are deliberately out of scope here — can be cleaned up in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)