### PR TITLE
fix: replace mis-copied python tegra configs with the real tegra content

### DIFF
--- a/src/apps/reference_apps/README.md
+++ b/src/apps/reference_apps/README.md
@@ -34,5 +34,5 @@ For further details on each app, please see each project's README.
 ### DeepStream VLLM Plugin: [README](deepstream-vllm-plugin/README.md) ###
  A GStreamer plugin for NVIDIA DeepStream that integrates Vision-Language Models (VLM) using VLLM for real-time video understanding and analysis.
 
-## Pyservicemaker Sample apps
+## Pyservicemaker Sample apps: [README](pyservicemaker_sample_apps/README.md)
 The apps in pyservicemaker_sample_apps are additional samples demonstrating usage of the Python API for DeepStream Service Maker, either by flow API or by pipeline API. See the [Python Service Maker documentation](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_service_maker_python.html) for details.

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test1_app/dstest1_config_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test1_app/dstest1_config_tegra.yaml
@@ -35,7 +35,6 @@ deepstream:
     name: infer
     properties:
       config-file-path: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test1/dstest1_pgie_config.yml
-      # output-tensor-meta: true
 ## Inference using nvinferserver: replace the above infer definition with below
 #  - type: nvinferserver
 #    name: infer
@@ -45,7 +44,7 @@ deepstream:
     name: nvvideoconvert
   - type: nvdsosd
     name: nvdsosd
-  - type: nveglglessink
+  - type: nv3dsink
     name: sink
     properties:
       sync: false
@@ -58,6 +57,8 @@ deepstream:
     h264parse: nvv4l2decoder
     nvv4l2decoder: nvstreammux
     nvstreammux: infer
-    infer: nvvideoconvert
+    infer.src:
+    - nvvideoconvert
+    - samplevideoprobe
     nvvideoconvert: nvdsosd
     nvdsosd: sink

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test2_app/dstest2_config_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test2_app/dstest2_config_tegra.yaml
@@ -70,7 +70,7 @@ deepstream:
     name: converter
   - type: nvdsosd
     name: nvdsosd
-  - type: nveglglessink
+  - type: nv3dsink
     name: sink
     properties:
       sync: false

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test3_app/dstest3_config_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test3_app/dstest3_config_tegra.yaml
@@ -69,8 +69,8 @@ deepstream:
     type: queue
   - name: queue4
     type: queue
-  - name: nveglglessink
-    type: nveglglessink
+  - name: sink
+    type: nv3dsink
   - name: nvdsosd
     type: nvdsosd
   - name: samplevideoprobe
@@ -88,7 +88,7 @@ deepstream:
     queue1: nvdslogger
     queue2: converter
     queue3: nvdsosd
-    queue4: nveglglessink
+    queue4: sink
     uridecodebin: nvstreammux
     uridecodebin1: nvstreammux
     uridecodebin2: nvstreammux

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test4_app/dstest4_config_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test4_app/dstest4_config_tegra.yaml
@@ -50,8 +50,8 @@ deepstream:
     type: queue
   - name: queue1
     type: queue
-  - name: nveglglessink
-    type: nveglglessink
+  - name: nv3dsink
+    type: nv3dsink
   - name: nvmsgconv
     properties:
       config: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test4/dstest4_msgconv_config.yml
@@ -76,7 +76,7 @@ deepstream:
     nvstreammux: infer
     nvv4l2decoder: nvstreammux
     nvvideoconvert: nvdsosd
-    queue.src: nveglglessink
+    queue.src: nv3dsink
     queue1.src: nvmsgconv
     tee:
     - queue

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source_tegra.yaml
@@ -63,8 +63,8 @@ deepstream:
   - type: nvmultistreamtiler
     name: tiler
     properties:
-      width: 1920
-      height: 1080
+      width: 1280
+      height: 720
   - type: nvdsosd
     name: osd
   - type: nvvideoconvert
@@ -91,7 +91,7 @@ deepstream:
     name: queue_sink
   - type: queue
     name: queue_msgbroker
-  - type: nveglglessink
+  - type: nv3dsink
     name: sink
     properties:
       async: false

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source_with_enable_property_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source_with_enable_property_tegra.yaml
@@ -69,8 +69,8 @@ deepstream:
   - type: nvmultistreamtiler
     name: tiler
     properties:
-      width: 1920
-      height: 1080
+      width: 1280
+      height: 720
   - type: nvdsosd
     name: osd
   - type: nvvideoconvert
@@ -97,7 +97,7 @@ deepstream:
     name: queue_sink
   - type: queue
     name: queue_msgbroker
-  - type: nveglglessink
+  - type: nv3dsink
     name: sink
     properties:
       async: false

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b2_tegra.yaml
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b2_tegra.yaml
@@ -87,7 +87,7 @@ deepstream:
     name: queue_sink
   - type: queue
     name: queue_msgbroker
-  - type: nveglglessink
+  - type: nv3dsink
     name: sink
     properties:
       async: false
@@ -100,7 +100,7 @@ deepstream:
     name: osd_counter
     properties:
       font-size: 15
-  edges:
+edges:
     pgie: [queue_tracker, osd_counter]
     queue_tracker: tracker
     tracker: queue_vehicle_type_classifier


### PR DESCRIPTION
The python/pipeline_api/<app>/*_tegra.yaml files were byte-for-byte copies of the corresponding *_x86.yaml configs in the same directory. As a result Tegra runs of the Python apps were picking up x86-only nodes (notably nveglglessink) and in some cases x86-only resolutions/topology.

Sync each python tegra config with its already-correct cpp/ sibling, which matches the rel-39 reference body content. Copying from cpp/ preserves the Apache-2.0 OSS header that this repo uses (the rel-39 source still carries the NvidiaProprietary header, so it can't be copied verbatim).

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
