### PR TITLE
build: move dependency installs to install_opensource_deps.sh and fix…

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -79,12 +79,14 @@ PLATFORM_MAKE_FLAGS=
 #  /opt/nvidia/deepstream/deepstream-${NVDS_VERSION}/lib/.)
 # ---------------------------------------------------------------------------
 echo "==> Installing open-source dependencies"
-run_as_root env NVDS_VERSION="$NVDS_VERSION" bash "$SCRIPT_DIR/../scripts/install_opensource_deps.sh"
+run_as_root env NVDS_VERSION="$NVDS_VERSION" PLATFORM="$PLATFORM" bash "$SCRIPT_DIR/../scripts/install_opensource_deps.sh"
 
 echo "==> Building PLATFORM=$PLATFORM CUDA_VER=$CUDA_VER (outputs directly to /opt/nvidia/deepstream/deepstream-${NVDS_VERSION}/)"
 echo "==> Using cmake: $CMAKE_BIN"
 
 MK="CUDA_VER=$CUDA_VER NVDS_VERSION=$NVDS_VERSION $PLATFORM_MAKE_FLAGS"
+
+FAILED_BUILDS=()
 
 # nvds_rest_server must be built before gstnvdscustomhelper (it links against it)
 run_as_root make -C src/utils/nvds_rest_server $MK
@@ -96,7 +98,8 @@ run_as_root make -C src/gst-utils/gstnvdscustomhelper $MK
 
 # Utils (no top-level Makefile — build each individually)
 for dir in src/utils/*/; do
-  run_as_root make -C "$dir" $MK 2>/dev/null || true
+  [ -f "$dir/Makefile" ] || continue
+  run_as_root make -C "$dir" $MK 2>/dev/null || FAILED_BUILDS+=("$dir")
 done
 
 # nvds_msgapi message broker adaptors (Makefiles live one level deeper than
@@ -104,17 +107,32 @@ done
 # device_client/ and module_client/).
 for dir in src/utils/nvds_msgapi/*/; do
   if [ -f "$dir/Makefile" ]; then
-    run_as_root make -C "$dir" $MK 2>/dev/null || true
+    run_as_root make -C "$dir" $MK 2>/dev/null || FAILED_BUILDS+=("$dir")
   else
     for sub in "$dir"*/; do
-      [ -f "$sub/Makefile" ] && run_as_root make -C "$sub" $MK 2>/dev/null || true
+      if [ -f "$sub/Makefile" ]; then
+        run_as_root make -C "$sub" $MK 2>/dev/null || FAILED_BUILDS+=("$sub")
+      fi
+    done
+  fi
+done
+
+# ds3d utilities (Makefiles are two levels deep: category/component/Makefile)
+for dir in src/utils/ds3d/*/; do
+  if [ -f "$dir/Makefile" ]; then
+    run_as_root make -C "$dir" $MK 2>/dev/null || FAILED_BUILDS+=("$dir")
+  else
+    for sub in "$dir"*/; do
+      if [ -f "$sub/Makefile" ]; then
+        run_as_root make -C "$sub" $MK 2>/dev/null || FAILED_BUILDS+=("$sub")
+      fi
     done
   fi
 done
 
 # GStreamer plugins (no top-level Makefile — build each individually)
 for dir in src/gst-plugins/*/; do
-  run_as_root make -C "$dir" $MK 2>/dev/null || true
+  run_as_root make -C "$dir" $MK 2>/dev/null || FAILED_BUILDS+=("$dir")
 done
 
 # Sample apps (no top-level Makefile — build each individually)
@@ -129,10 +147,13 @@ for dir in src/apps/sample_apps/*/; do
     echo "Skipping deepstream-ucx-test on $PLATFORM (x86 only)"
     continue
   fi
-  make -C "$dir" $MK BIN_DIR="$SA_BIN_STAGE" 2>/dev/null || true
-  for bin in "$SA_BIN_STAGE"/deepstream-*; do
-    [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true
-  done
+  if make -C "$dir" $MK BIN_DIR="$SA_BIN_STAGE" 2>/dev/null; then
+    for bin in "$SA_BIN_STAGE"/deepstream-*; do
+      [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true
+    done
+  else
+    FAILED_BUILDS+=("$dir")
+  fi
   rm -f "$SA_BIN_STAGE"/deepstream-*
 done
 rm -rf "$SA_BIN_STAGE"
@@ -143,20 +164,23 @@ run_as_root apt install -y libeigen3-dev
 run_as_root ln -sf /usr/include/eigen3/Eigen /usr/include/Eigen
 
 #Customized Yolo postprocessing lib
-make -C tools/yolo_deepstream/deepstream_yolo/nvdsinfer_custom_impl_Yolo/ $MK 2>/dev/null || true
+make -C tools/yolo_deepstream/deepstream_yolo/nvdsinfer_custom_impl_Yolo/ $MK 2>/dev/null || FAILED_BUILDS+=("tools/yolo_deepstream/deepstream_yolo/nvdsinfer_custom_impl_Yolo/")
 
 # tao-apps — build and install via top-level Makefile
 git submodule update --init --recursive || true
-run_as_root make -C src/apps/tao_apps $MK 2>/dev/null || true
+run_as_root make -C src/apps/tao_apps $MK 2>/dev/null || FAILED_BUILDS+=("src/apps/tao_apps")
 
 # Reference apps (no top-level Makefile — build each individually)
 RA_BIN_STAGE=/tmp/ds-reference-apps-bin
 mkdir -p "$RA_BIN_STAGE"
 for dir in src/apps/reference_apps/*/; do
-  make -C "$dir" $MK BIN_DIR="$RA_BIN_STAGE" 2>/dev/null || true
-  for bin in "$RA_BIN_STAGE"/deepstream-*; do
-    [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true
-  done
+  if make -C "$dir" $MK BIN_DIR="$RA_BIN_STAGE" 2>/dev/null; then
+    for bin in "$RA_BIN_STAGE"/deepstream-*; do
+      [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true
+    done
+  else
+    FAILED_BUILDS+=("$dir")
+  fi
   rm -f "$RA_BIN_STAGE"/deepstream-*
 done
 rm -rf "$RA_BIN_STAGE"
@@ -186,4 +210,13 @@ for dir in src/service-maker/sources/modules/*/; do
 done
 rm -rf "$SM_MOD_BUILD"
 
-echo "==> Done"
+if [ ${#FAILED_BUILDS[@]} -gt 0 ]; then
+  echo ""
+  echo "==> Build completed with ${#FAILED_BUILDS[@]} failure(s):"
+  for fb in "${FAILED_BUILDS[@]}"; do
+    echo "    FAILED: $fb"
+  done
+  echo ""
+else
+  echo "==> Done (all builds succeeded)"
+fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -142,9 +142,15 @@ SA_BIN_STAGE=/tmp/ds-sample-apps-bin
 DS_BIN=/opt/nvidia/deepstream/deepstream-${NVDS_VERSION}/bin
 mkdir -p "$SA_BIN_STAGE"
 for dir in src/apps/sample_apps/*/; do
-  # deepstream-ucx-test is x86-only (no aarch64 UCX support shipped)
-  if [ "$PLATFORM" != "x86" ] && [ "$(basename "$dir")" = "deepstream-ucx-test" ]; then
-    echo "Skipping deepstream-ucx-test on $PLATFORM (x86 only)"
+  app=$(basename "$dir")
+  # x86-only apps
+  if [ "$PLATFORM" != "x86" ] && [[ "$app" == "deepstream-ucx-test" || "$app" == "deepstream-multigpu-nvlink-test" ]]; then
+    echo "Skipping $app on $PLATFORM (x86 only)"
+    continue
+  fi
+  # Jetson-only apps
+  if [ "$PLATFORM" = "x86" ] && [ "$app" = "deepstream-ipc-test" ]; then
+    echo "Skipping $app on $PLATFORM (Jetson only)"
     continue
   fi
   if make -C "$dir" $MK BIN_DIR="$SA_BIN_STAGE" 2>/dev/null; then

--- a/scripts/install_opensource_deps.sh
+++ b/scripts/install_opensource_deps.sh
@@ -8,14 +8,38 @@
 #   prometheus-cpp     v1.2.4             -> libprometheus-cpp-core.so
 #   azure-iot-sdk-c    commit dbeb521e     -> libiothub_client.so (v1.11.0)
 #
+# Additional prerequisites installed:
+#   half               v2.1.0             -> /opt/half
+#   triton gRPC client v2.65.0            -> /opt/tritonclient
+#   protobuf compiler  v3.21.12           -> /opt/proto
+#   apt packages: libpango, libcairo, libjson-glib, librabbitmq, librdkafka, etc.
+#   mosquitto (from PPA)
+#
 # Usage:
-#   sudo bash scripts/install_opensource_deps.sh [NVDS_VERSION=9.0]
+#   sudo PLATFORM=x86 bash scripts/install_opensource_deps.sh [NVDS_VERSION=9.0]
+#   sudo PLATFORM=aarch64 bash scripts/install_opensource_deps.sh [NVDS_VERSION=9.0]
 
 set -e
 
 NVDS_VERSION=${NVDS_VERSION:-9.0}
 INSTALL_DIR=/opt/nvidia/deepstream/deepstream-${NVDS_VERSION}/lib
 BUILD_ROOT=$(mktemp -d /tmp/ds-deps-build.XXXXXX)
+
+# Detect platform if not passed via environment
+if [ -z "${PLATFORM:-}" ]; then
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64)  PLATFORM=x86 ;;
+    aarch64)
+      if [ -f /etc/nv_tegra_release ]; then
+        PLATFORM=aarch64
+      else
+        PLATFORM=sbsa
+      fi
+      ;;
+    *)  echo "Unsupported architecture: $ARCH"; exit 1 ;;
+  esac
+fi
 
 echo "==> Installing open-source DeepStream dependencies"
 echo "    Install dir : $INSTALL_DIR"
@@ -108,29 +132,108 @@ cmake --install "$BUILD_ROOT/prom-build"
 find "$BUILD_ROOT/prom-install/lib" -name "libprometheus-cpp-core.so*" -exec cp -Pv {} "$INSTALL_DIR/" \;
 
 # ---------------------------------------------------------------------------
-# 4. azure-iot-sdk-c LTS_01_2023_Ref01 (v1.11.0)
+# 4. azure-iot-sdk-c v1.11.0
+#    (follows README in src/utils/nvds_msgapi/azure_protocol_adaptor/module_client)
 # ---------------------------------------------------------------------------
 echo ""
-echo "--- azure-iot-sdk-c v1.11.0 (commit dbeb521e) ---"
+echo "--- azure-iot-sdk-c v1.11.0 ---"
 AZURE_DIR=$BUILD_ROOT/azure-iot-sdk-c
-# LTS_01_2023_Ref01 tag = v1.10.0; v1.11.0 is the next commit (dbeb521e)
-git clone --recursive https://github.com/Azure/azure-iot-sdk-c.git "$AZURE_DIR"
-git -C "$AZURE_DIR" checkout dbeb521e
-git -C "$AZURE_DIR" submodule update --init --recursive
-cmake -S "$AZURE_DIR" -B "$BUILD_ROOT/azure-build" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -Dbuild_as_dynamic=ON \
-    -Duse_edge_modules=ON \
-    -Dskip_samples=ON \
-    -Duse_amqp=ON \
-    -Duse_mqtt=ON \
-    -Duse_http=ON \
-    -DCMAKE_INSTALL_PREFIX="$BUILD_ROOT/azure-install" \
-    -Wno-dev
-cmake --build "$BUILD_ROOT/azure-build" -j$(nproc)
-cmake --install "$BUILD_ROOT/azure-build"
+git clone https://github.com/Azure/azure-iot-sdk-c.git "$AZURE_DIR"
+git -C "$AZURE_DIR" checkout tags/1.11.0
+git -C "$AZURE_DIR" submodule update --init
 
-find "$BUILD_ROOT/azure-install/lib" -name "libiothub_client.so*" -exec cp -Pv {} "$INSTALL_DIR/" \;
+# Enable build_as_dynamic and use_edge_modules in CMakeLists.txt
+sed -i 's/\(option(build_as_dynamic.*\)OFF)/\1ON)/' "$AZURE_DIR/CMakeLists.txt"
+sed -i 's/\(option(use_edge_modules.*\)OFF)/\1ON)/' "$AZURE_DIR/CMakeLists.txt"
+
+mkdir -p "$AZURE_DIR/cmake"
+cmake -S "$AZURE_DIR" -B "$AZURE_DIR/cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -Dskip_samples=ON \
+    -Wno-dev
+cmake --build "$AZURE_DIR/cmake" -j$(nproc)
+cmake --install "$AZURE_DIR/cmake"
+
+find /usr/local/lib -name "libiothub_client.so*" -exec cp -Pv {} "$INSTALL_DIR/" \;
+
+# ---------------------------------------------------------------------------
+# 5. Half v2.1.0
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Half v2.1.0 ---"
+mkdir -p /opt/half
+wget -q -P /tmp https://sourceforge.net/projects/half/files/half/2.1.0/half-2.1.0.zip
+unzip -o /tmp/half-2.1.0.zip -d /opt/half/
+rm -f /tmp/half-2.1.0.zip
+
+# ---------------------------------------------------------------------------
+# 6. Triton gRPC Client v2.65.0
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Triton gRPC Client v2.65.0 (PLATFORM=$PLATFORM) ---"
+mkdir -p /opt/tritonclient/
+if [ "$PLATFORM" = "x86" ]; then
+  wget -q -P /tmp https://github.com/triton-inference-server/server/releases/download/v2.65.0/v2.65.0_ubuntu2404.clients.tar.gz
+  tar xzf /tmp/v2.65.0_ubuntu2404.clients.tar.gz -C /opt/tritonclient/ lib include
+  rm -f /tmp/v2.65.0_ubuntu2404.clients.tar.gz
+else
+  # Jetson (aarch64) — use the igpu tar; switch to tritonserver2.60.0-agx.tar for AGX systems
+  wget -q -P /tmp https://github.com/triton-inference-server/server/releases/download/v2.60.0/tritonserver2.60.0-agx.tar
+  tar xf /tmp/tritonserver2.60.0-agx.tar -C /opt/tritonclient/ --strip-components=2 tritonserver/clients/lib/ tritonserver/clients/include/
+  rm -f /tmp/tritonserver2.60.0-agx.tar
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Protobuf compiler v3.21.12
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Protobuf compiler v3.21.12 (PLATFORM=$PLATFORM) ---"
+mkdir -p /opt/proto
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+if [ "$PLATFORM" = "x86" ]; then
+  curl -Lo /tmp/protoc-21.12.zip "$PB_REL/download/v21.12/protoc-21.12-linux-x86_64.zip"
+else
+  curl -Lo /tmp/protoc-21.12.zip "$PB_REL/download/v21.12/protoc-21.12-linux-aarch_64.zip"
+fi
+unzip -o /tmp/protoc-21.12.zip -d /opt/proto
+chmod -R +rx /opt/proto/
+rm -f /tmp/protoc-21.12.zip
+
+# ---------------------------------------------------------------------------
+# 8. APT library dependencies
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- APT library dependencies ---"
+apt-get update
+apt-get install -y \
+  libpango1.0-dev libcairo2-dev libjpeg-dev \
+  libglib2.0-dev libjson-glib-dev uuid-dev libyaml-cpp-dev \
+  librabbitmq-dev librdkafka-dev \
+  libjansson4 libjansson-dev \
+  libssl-dev libcjson-dev libhiredis-dev
+
+# ---------------------------------------------------------------------------
+# 9. Mosquitto
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Mosquitto ---"
+apt-add-repository -y ppa:mosquitto-dev/mosquitto-ppa
+apt-get update
+apt-get install -y libmosquitto-dev mosquitto
+
+# ---------------------------------------------------------------------------
+# 10. Sample-app build prerequisites
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Sample-app build prerequisites ---"
+apt-get update
+apt-get install -y \
+  libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
+  libgstrtspserver-1.0-dev libx11-dev \
+  gstreamer1.0-libav libavahi-compat-libdnssd-dev \
+  libjson-glib-dev libjsoncpp-dev libyaml-cpp-dev \
+  libgbm1 libglapi-mesa libgles2-mesa-dev \
+  rapidjson-dev
 
 # ---------------------------------------------------------------------------
 # Cleanup and ldconfig

--- a/src/gst-plugins/gst-nvdsmetautils/audio_metadata_serialization/Makefile
+++ b/src/gst-plugins/gst-nvdsmetautils/audio_metadata_serialization/Makefile
@@ -27,7 +27,7 @@ CFLAGS:= -Wall -std=c++11 -shared -fPIC
 
 CFLAGS+= -fPIC -DDS_VERSION=\"9.0\" \
 	 -I /usr/local/cuda-$(CUDA_VER)/include \
-	 -I ../../../includes
+	 -I ../../../../includes
 
 CFLAGS+= -I/opt/tritonclient/include
 

--- a/src/gst-plugins/gst-nvdsmetautils/sei_serialization/Makefile
+++ b/src/gst-plugins/gst-nvdsmetautils/sei_serialization/Makefile
@@ -31,7 +31,7 @@ NVDS_VERSION?=9.0
 
 CFLAGS+= -fPIC -DDS_VERSION=\"9.0.0\" \
 	 -I /usr/local/cuda-$(CUDA_VER)/include \
-	 -I ../../../includes
+	 -I ../../../../includes
 
 GST_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/gst-plugins/
 LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/

--- a/src/gst-plugins/gst-nvdsmetautils/video_metadata_serialization/Makefile
+++ b/src/gst-plugins/gst-nvdsmetautils/video_metadata_serialization/Makefile
@@ -27,7 +27,7 @@ CFLAGS:= -Wall -std=c++11 -shared -fPIC
 
 CFLAGS+= -fPIC -DDS_VERSION=\"9.0\" \
 	 -I /usr/local/cuda-$(CUDA_VER)/include \
-	 -I ../../../includes
+	 -I ../../../../includes
 
 CFLAGS+= -I/opt/tritonclient/include
 

--- a/src/utils/ds3d/datafilter/lidar_preprocess/Makefile
+++ b/src/utils/ds3d/datafilter/lidar_preprocess/Makefile
@@ -21,7 +21,7 @@ ifeq ($(CUDA_VER),)
 endif
 
 
-LIB_INSTALL_DIR ?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
+LIB_INSTALL_DIR ?= /opt/nvidia/deepstream/deepstream/lib/
 CC:= g++
 
 NVCC:=/usr/local/cuda-$(CUDA_VER)/bin/nvcc

--- a/src/utils/ds3d/dataloader/lidarsource/Makefile
+++ b/src/utils/ds3d/dataloader/lidarsource/Makefile
@@ -36,7 +36,7 @@ ifeq ($(NVDS_VERSION),)
   NVDS_VERSION:=$(shell basename $(FULL_PATH) | cut -f2 -d -)
 endif
 
-DS_HOME=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)
+DS_HOME=/opt/nvidia/deepstream/deepstream
 LIB_INSTALL_DIR=$(DS_HOME)/lib
 
 $(info NVDS_VERSION=$(NVDS_VERSION))

--- a/src/utils/nvds_msgapi/amqp_protocol_adaptor/Makefile
+++ b/src/utils/nvds_msgapi/amqp_protocol_adaptor/Makefile
@@ -23,12 +23,12 @@ CXX:=g++
 
 PKGS:= glib-2.0 
 
-DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+DS_LIB:=/opt/nvidia/deepstream/deepstream/lib
 
 SRCS:=  amqp_client.cpp ../common_src/nvds_utils.cpp
 TARGET_LIB:= libnvds_amqp_proto.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 
 CFLAGS:= -fPIC -Wall
 

--- a/src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/Makefile
+++ b/src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/Makefile
@@ -22,12 +22,12 @@ CXX:=g++
 
 PKGS:= glib-2.0 
 
-DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+DS_LIB:=/opt/nvidia/deepstream/deepstream/lib
 
 SRCS:=  azure_device_client.cpp ../../common_src/nvds_utils.cpp
 TARGET_LIB:= libnvds_azure_proto.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 
 CFLAGS:= -fPIC -Wall
 

--- a/src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/Makefile
+++ b/src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/Makefile
@@ -22,12 +22,12 @@ CXX:=g++
 
 PKGS:= glib-2.0 
 
-DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+DS_LIB:=/opt/nvidia/deepstream/deepstream/lib
 
 SRCS:=  azure_module_client.cpp
 TARGET_LIB:= libnvds_azure_edge_proto.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 
 CFLAGS:= -fPIC -Wall
 

--- a/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile
+++ b/src/utils/nvds_msgapi/kafka_protocol_adaptor/Makefile
@@ -21,7 +21,7 @@ CXX:=g++
 
 PKGS:= glib-2.0
 
-DS_LIB:=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+DS_LIB:=/opt/nvidia/deepstream/deepstream/lib
 
 PROTOBUF_BUILD_DIR:= .
 PROTOBUF_BIN_DIR ?= /opt/proto/bin
@@ -29,7 +29,7 @@ PROTOBUF_BIN_DIR ?= /opt/proto/bin
 SRCS:=  nvds_kafka_proto.cpp kafka_client.cpp json_helper.cpp ../common_src/nvds_utils.cpp $(PROTOBUF_BUILD_DIR)/schema.pb.cc
 TARGET_LIB:= libnvds_kafka_proto.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 
 CFLAGS:= -fPIC -Wall
 

--- a/src/utils/nvds_msgapi/mqtt_protocol_adaptor/Makefile
+++ b/src/utils/nvds_msgapi/mqtt_protocol_adaptor/Makefile
@@ -21,7 +21,7 @@ CXX:=g++
 
 PKGS:= glib-2.0 
 
-DS_LIB := /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
+DS_LIB := /opt/nvidia/deepstream/deepstream/lib/
 
 SRCS:=  nvds_mqtt_proto.cpp ../common_src/nvds_utils.cpp
 
@@ -36,7 +36,7 @@ CFLAGS+= $(shell pkg-config --cflags $(PKGS))
 LIBS:= $(shell pkg-config --libs $(PKGS))
 LDFLAGS:= -shared
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 DS_INC:= ../../../../includes
 MOSQ_INC:=/usr/local/include/
 

--- a/src/utils/nvds_msgapi/redis_protocol_adaptor/Makefile
+++ b/src/utils/nvds_msgapi/redis_protocol_adaptor/Makefile
@@ -23,12 +23,12 @@ CXX:=g++
 
 PKGS:= glib-2.0 
 
-DS_LIB := /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
+DS_LIB := /opt/nvidia/deepstream/deepstream/lib/
 
 SRCS:=  nvds_redis_client.cpp ../common_src/nvds_utils.cpp
 TARGET_LIB:= libnvds_redis_proto.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream/lib
 
 CFLAGS:= -fPIC -Wall
 


### PR DESCRIPTION
## Description

Refactored the build system to separate dependency installation from compilation and added Jetson (aarch64) platform support.

- Moved all prerequisite installs (Half, Triton gRPC client, Protobuf compiler, apt libraries, Mosquitto, Eigen, sample-app dev packages)  into `scripts/install_opensource_deps.sh`
- Added platform detection so the dependency script downloads the correct Triton and Protobuf archives for x86 vs Jetson/aarch64
- Updated azure-iot-sdk-c build steps to follow the README in `src/utils/nvds_msgapi/azure_protocol_adaptor/module_client/`
- Added build logic for `src/utils/ds3d/` components (nested Makefiles for lidar dataloader, datafilter, and inference custom libs)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
