### PR TITLE
fix(gst-nvmultistream2): add aarch64 tegra library path for linker

### DIFF
--- a/scripts/install_opensource_deps.sh
+++ b/scripts/install_opensource_deps.sh
@@ -217,6 +217,8 @@ apt-get install -y \
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Mosquitto ---"
+apt-get update
+apt install -y software-properties-common
 apt-add-repository -y ppa:mosquitto-dev/mosquitto-ppa
 apt-get update
 apt-get install -y libmosquitto-dev mosquitto

--- a/src/apps/sample_apps/TritonBackendEnsemble/README
+++ b/src/apps/sample_apps/TritonBackendEnsemble/README
@@ -145,6 +145,14 @@ NOTE: Run with "sudo -E" or root if there is file permission issues.
    $ cd build
    $ make install
    $ cp install/backends/recommended/libtriton_recommended.so ../triton_model_repo/deepstream_triton_custom_cpp_backend/1/
+   $ cp install/backends/recommended/libtriton_recommended.so /opt/tritonserver/backends/recommended/
+
+   $ cd /opt/nvidia/deepstream/deepstream/samples
+   $ ./prepare_ds_triton_model_repo.sh
+   $ cd -   # back to: .../src/apps/sample_apps/TritonBackendEnsemble
+   $ ln -s /opt/nvidia/deepstream/deepstream/samples/triton_model_repo/Primary_Detector triton_model_repo/Primary_Detector
+   $ ln -s /opt/nvidia/deepstream/deepstream/samples/triton_model_repo/Secondary_VehicleMake triton_model_repo/Secondary_VehicleMake
+   $ ln -s /opt/nvidia/deepstream/deepstream/samples/triton_model_repo/Secondary_VehicleTypes triton_model_repo/Secondary_VehicleTypes
 
 NOTE: To compile the sources, run make with "sudo -E" or root permission.
 

--- a/src/apps/sample_apps/TritonBackendEnsemble/config_infer_primary.txt
+++ b/src/apps/sample_apps/TritonBackendEnsemble/config_infer_primary.txt
@@ -62,7 +62,7 @@ infer_config {
   }
 
   postprocess {
-    labelfile_path: "../../samples/models/Primary_Detector/labels.txt"
+    labelfile_path: "/opt/nvidia/deepstream/deepstream/samples/models/Primary_Detector/labels.txt"
     detection {
       num_detected_classes: 4
       per_class_params {

--- a/src/apps/sample_apps/TritonBackendEnsemble/deepstream_app_config_triton_backend_ensemble.txt
+++ b/src/apps/sample_apps/TritonBackendEnsemble/deepstream_app_config_triton_backend_ensemble.txt
@@ -38,7 +38,7 @@ nvbuf-memory-type=0
 enable=1
 #Type - 1=CameraV4L2 2=URI 3=MultiURI 4=RTSP
 type=3
-uri=file://../../samples/streams/sample_1080p_h264.mp4
+uri=file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h264.mp4
 num-sources=4
 #drop-frame-interval=2
 gpu-id=0
@@ -154,11 +154,11 @@ tracker-width=960
 tracker-height=544
 ll-lib-file=/opt/nvidia/deepstream/deepstream/lib/libnvds_nvmultiobjecttracker.so
 # ll-config-file required to set different tracker types
-# ll-config-file=../deepstream-app/config_tracker_IOU.yml
-# ll-config-file=../deepstream-app/config_tracker_NvSORT.yml
-ll-config-file=../deepstream-app/config_tracker_NvDCF_perf.yml
-# ll-config-file=../deepstream-app/config_tracker_NvDCF_accuracy.yml
-# ll-config-file=../deepstream-app/config_tracker_NvDeepSORT.yml
+# ll-config-file=/opt/nvidia/deepstream/deepstream/samples/configs/deepstream-app/config_tracker_IOU.yml
+# ll-config-file=/opt/nvidia/deepstream/deepstream/samples/configs//deepstream-app/config_tracker_NvSORT.yml
+ll-config-file=/opt/nvidia/deepstream/deepstream/samples/configs/deepstream-app/config_tracker_NvDCF_perf.yml
+# ll-config-file=/opt/nvidia/deepstream/deepstream/samples/configs//deepstream-app/config_tracker_NvDCF_accuracy.yml
+# ll-config-file=/opt/nvidia/deepstream/deepstream/samples/configs//deepstream-app/config_tracker_NvDeepSORT.yml
 gpu-id=0
 display-tracking-id=1
 

--- a/src/gst-plugins/gst-nvdsvideotemplate/customlib_impl/Makefile
+++ b/src/gst-plugins/gst-nvdsvideotemplate/customlib_impl/Makefile
@@ -31,7 +31,7 @@ NVDS_VERSION?=9.0
 
 CFLAGS+= -fPIC -DDS_VERSION=\"9.0.0\" \
 	 -I /usr/local/cuda-$(CUDA_VER)/include \
-	 -I ../../../includes -I../includes
+	 -I ../../../../includes -I../includes
 
 GST_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/gst-plugins/
 LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/

--- a/src/gst-plugins/gst-nvmultistream2/Makefile
+++ b/src/gst-plugins/gst-nvmultistream2/Makefile
@@ -22,6 +22,7 @@ endif
 
 PKGS:= glib-2.0 gobject-2.0 json-glib-1.0 uuid
 PKGS += gstreamer-1.0 gstreamer-base-1.0 gstreamer-audio-1.0 gstreamer-video-1.0
+TARGET_DEVICE = $(shell gcc -dumpmachine | cut -f1 -d -)
 
 CXX:= g++
 
@@ -43,6 +44,9 @@ CFLAGS+= -fPIC -DDS_VERSION=\"9.0.0\" \
 GST_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/gst-plugins/
 LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
 
+ifeq ($(TARGET_DEVICE),aarch64)
+	LIBS := -L/usr/lib/aarch64-linux-gnu/tegra
+endif
 
 LIBS+= -shared -Wl,-no-undefined \
 	-L$(GST_INSTALL_DIR) -lnvdsgst_multistream_legacy \


### PR DESCRIPTION
## Description
Restore aarch64-specific linker configuration for `gst-nvmultistream2`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
