### PR TITLE
fix(utils): nvmsgconv Makefiles use local build + cp to avoid breakin…

### DIFF
--- a/src/utils/nvmsgconv/Makefile
+++ b/src/utils/nvmsgconv/Makefile
@@ -48,21 +48,21 @@ SRCFILES:= nvmsgconv.cpp  \
   $(PROTOBUF_BUILD_DIR)/lidar_schema.pb.cc
 
 TARGET_LIB:= libnvds_msgconv.so
-LIB_DIR := /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
 OBJ_DIR := .build
 include ../../Rules.mk
 
-all: $(LIB_DIR)/$(TARGET_LIB)
+all: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 
-$(LIB_DIR)/$(TARGET_LIB): $(SRCFILES)
-	@mkdir -p $(LIB_DIR)
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
-
-install: $(LIB_DIR)/$(TARGET_LIB)
+install: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 	ldconfig
 
+$(TARGET_LIB) : $(SRCFILES)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
 clean:
-	rm -rf $(LIB_DIR)/$(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
+	rm -rf $(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
 
 SCHEMA_PROTOS:=$(wildcard deepstream_schema/*.proto)
 $(PROTOBUF_BUILD_DIR)/%.pb.cc: $(SCHEMA_PROTOS) Makefile

--- a/src/utils/nvmsgconv_mega/Makefile
+++ b/src/utils/nvmsgconv_mega/Makefile
@@ -49,19 +49,18 @@ SRCFILES:= nvmsgconv_mega.cpp  \
 
 TARGET_LIB:= libnvds_msgconv_mega.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+all: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 
-all: $(UTILS_LIB_DIR)/$(TARGET_LIB)
-
-$(UTILS_LIB_DIR)/$(TARGET_LIB): $(SRCFILES)
-	@mkdir -p $(UTILS_LIB_DIR)
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
-
-install: $(UTILS_LIB_DIR)/$(TARGET_LIB)
+install: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 	ldconfig
 
+$(TARGET_LIB) : $(SRCFILES)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
 clean:
-	rm -rf $(UTILS_LIB_DIR)/$(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
+	rm -rf $(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
 
 SCHEMA_PROTOS:=$(wildcard deepstream_schema/*.proto)
 $(PROTOBUF_BUILD_DIR)/%.pb.cc: $(SCHEMA_PROTOS) Makefile

--- a/src/utils/nvmsgconv_mega2d/Makefile
+++ b/src/utils/nvmsgconv_mega2d/Makefile
@@ -49,19 +49,18 @@ SRCFILES:= nvmsgconv.cpp  \
 
 TARGET_LIB:= libnvds_msgconv_mega2d.so
 
-UTILS_LIB_DIR?= /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib
+all: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 
-all: $(UTILS_LIB_DIR)/$(TARGET_LIB)
-
-$(UTILS_LIB_DIR)/$(TARGET_LIB): $(SRCFILES)
-	@mkdir -p $(UTILS_LIB_DIR)
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
-
-install: $(UTILS_LIB_DIR)/$(TARGET_LIB)
+install: $(TARGET_LIB)
+	cp -rv $(TARGET_LIB) $(LIB_INSTALL_DIR)
 	ldconfig
 
+$(TARGET_LIB) : $(SRCFILES)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
 clean:
-	rm -rf $(UTILS_LIB_DIR)/$(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
+	rm -rf $(TARGET_LIB) $(PROTOBUF_BUILD_DIR)/*.pb.*
 
 SCHEMA_PROTOS:=$(wildcard deepstream_schema/*.proto)
 $(PROTOBUF_BUILD_DIR)/%.pb.cc: $(SCHEMA_PROTOS) Makefile


### PR DESCRIPTION
## fix(utils): build nvmsgconv libs locally and copy to DeepStream lib dir

- Build libnvds_msgconv{,_mega,_mega2d}.so in the source tree and install with cp into /opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib instead of linking directly into that path. 
- This matches the packaged sources Makefile behavior and preserves Debian symlinks (cp updates .so.1.0.0 through the symlink).
- On x86, regular .so files are replaced in place without creating symlinks.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
