### PR TITLE
fix(build): install patched GStreamer rtpmanager and RTSP plugins aft…

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This project is currently not accepting contributions.
 - Labeling/triage policy: <link>
 
 ## Security
-- Vulnerability disclosure: `SECURITY.md`
+- Vulnerability disclosure: [SECURITY.md](https://github.com/NVIDIA/DeepStream/blob/main/SECURITY.md)
 - Do not file public issues for security reports.
 
 ## Support

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -34,6 +34,7 @@ sudo apt-get install cmake
    sudo apt remove libglapi-amber
    sudo apt install ./deepstream-9.0_9.0.0-1_amd64.deb
    sudo /opt/nvidia/deepstream/deepstream-9.0/install.sh
+   sudo bash /opt/nvidia/deepstream/deepstream/update_rtpmanager.sh
    export LD_LIBRARY_PATH=/opt/nvidia/deepstream/deepstream-9.0/lib:$LD_LIBRARY_PATH
    ```
    Append the `export` line to `~/.bashrc` to persist it across shells.
@@ -71,6 +72,7 @@ sudo apt-get install cmake
    sudo apt remove libglapi-amber
    sudo apt install ./deepstream-9.0_9.0.0-1_arm64.deb
    sudo /opt/nvidia/deepstream/deepstream-9.0/install.sh
+   sudo bash /opt/nvidia/deepstream/deepstream/update_rtpmanager.sh
    export LD_LIBRARY_PATH=/opt/nvidia/deepstream/deepstream-9.0/lib:$LD_LIBRARY_PATH
    ```
    Append the `export` line to `~/.bashrc` to persist it across shells.

--- a/build/build.sh
+++ b/build/build.sh
@@ -216,6 +216,8 @@ for dir in src/service-maker/sources/modules/*/; do
 done
 rm -rf "$SM_MOD_BUILD"
 
+# run update_rtpmanager.sh
+run_as_root bash /opt/nvidia/deepstream/deepstream/update_rtpmanager.sh
 if [ ${#FAILED_BUILDS[@]} -gt 0 ]; then
   echo ""
   echo "==> Build completed with ${#FAILED_BUILDS[@]} failure(s):"

--- a/build/build.sh
+++ b/build/build.sh
@@ -216,8 +216,6 @@ for dir in src/service-maker/sources/modules/*/; do
 done
 rm -rf "$SM_MOD_BUILD"
 
-# run update_rtpmanager.sh
-run_as_root bash /opt/nvidia/deepstream/deepstream/update_rtpmanager.sh
 if [ ${#FAILED_BUILDS[@]} -gt 0 ]; then
   echo ""
   echo "==> Build completed with ${#FAILED_BUILDS[@]} failure(s):"


### PR DESCRIPTION
## fix(build): install patched GStreamer rtpmanager

1. Run update_rtpmanager.sh at the end of build.sh to apply DeepStream GStreamer patches and deploy libgstrtpmanager, libgstrtsp, and libgstvideoparsersbad. 
2. Fix SECURITY.md link in README.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
