### PR TITLE
6242551 docs: fix typos, broken link, and malformed URL in tao/ref READMEs

### DIFF
--- a/src/apps/reference_apps/README.md
+++ b/src/apps/reference_apps/README.md
@@ -1,6 +1,6 @@
 # Reference Apps using DeepStream 9.0
 
-This repository contains the reference applications for video analytics tasks using TensorRT and DeepSTream SDK 9.0.
+This repository contains the reference applications for video analytics tasks using TensorRT and DeepStream SDK 9.0.
 
 ## Getting Started ##
 We currently provide different DeepStream reference applications:

--- a/src/apps/tao_apps/README.md
+++ b/src/apps/tao_apps/README.md
@@ -53,7 +53,7 @@ uridecoderbin -->streammux-->nvinfer(detection)-->nvosd-->
 
 * [DeepStream SDK 9.0 GA](https://developer.nvidia.com/deepstream-sdk)
 
-   Make sure deepstream-test1 sample can run successful to verify your installation. According to the
+   Make sure deepstream-test1 sample can run successfully to verify your installation. According to the
    [document](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_docker_containers.html),
    please run below command to install additional audio video packages.
 

--- a/src/apps/tao_apps/apps/tao_others/deepstream-mdx-perception-app/README.md
+++ b/src/apps/tao_apps/apps/tao_others/deepstream-mdx-perception-app/README.md
@@ -34,7 +34,7 @@ The application pipeline graph
 ![MDX perception application pipeline](mdx_perception_pipeline.png)
 
 ## Build And Run
-The application can be build and run seperately. Download the pre-trained models if haven't.
+The application can be built and run separately. Download the pre-trained models if you haven't.
 ```
 export DS_TAO_APPS_HOME=<path to tao_apps>
 cd $DS_TAO_APPS_HOME

--- a/src/apps/tao_apps/apps/tao_others/deepstream-nvocdr-app/README.md
+++ b/src/apps/tao_apps/apps/tao_others/deepstream-nvocdr-app/README.md
@@ -69,7 +69,7 @@ cp libnvinfer_plugin.so.8.6.x /usr/lib/aarch64-linux-gnu/libnvinfer_plugin.so.8.
 ```
 
 ## Build And Run
-The application can be build and run seperately.
+The application can be built and run separately.
 
 Prepare OCDNet/OCRNet engine file
 ```bash

--- a/src/apps/tao_apps/deepstream_app_tao_configs/README.md
+++ b/src/apps/tao_apps/deepstream_app_tao_configs/README.md
@@ -88,6 +88,6 @@ $ sudo deepstream-app -c deepstream_app_source1_trafficcamnet_vehiclemakenet_veh
 *******************************************************************************
 ## 4. Related Links
 *******************************************************************************
-deepstream-tao-app : https://github.com/DeepStream/deepstream/-/tree/main/src/apps/tao_apps
+deepstream-tao-app : https://github.com/NVIDIA/DeepStream/tree/main/src/apps/tao_apps
 
 TAO Toolkit Guide : https://docs.nvidia.com/tao/tao-toolkit/index.html

--- a/src/apps/tao_apps/triton_server_grpc.md
+++ b/src/apps/tao_apps/triton_server_grpc.md
@@ -19,8 +19,6 @@ To start Triton Server with DeepStream Triton container, the docker should be ru
     docker run --gpus all -it  --ipc=host --rm --privileged -v /tmp/.X11-unix:/tmp/.X11-unix  -p 10000:8000 -p 10001:8001 -p 10002:8002  -v $(pwd):/samples   -e DISPLAY=$DISPLAY -w /samples nvcr.io/nvidia/deepstream:9.0-triton-devel
 ```
 
-For TensorRT 8.6, the OSS libnvinfer_plugin.so should be updated according to [OSS TRT x86 instruction](TRT-OSS/x86/README.md) or [OSS TRT Jetson instruction](TRT-OSS/Jetson/README.md).
-
 Then the model engines should be generated in the server:
 
 ```


### PR DESCRIPTION
## Summary

Documentation cleanup found during a QA audit of the DS 9.0 mono-repo. Docs-only; no functional changes.

**Typos in user-facing READMEs**
- `src/apps/reference_apps/README.md:3` — `DeepSTream` → `DeepStream` (carryover from bug 6217670 — that bug was marked Fixed, but this instance remained)
- `src/apps/tao_apps/README.md:56` — "deepstream-test1 sample can run **successful**" → `successfully`
- `src/apps/tao_apps/apps/tao_others/deepstream-mdx-perception-app/README.md:37` — "can **be build** and run **seperately**. Download the pre-trained models **if haven't**." → "can be built and run separately. Download the pre-trained models if you haven't."
- `src/apps/tao_apps/apps/tao_others/deepstream-nvocdr-app/README.md:72` — "can **be build** and run **seperately**." → "can be built and run separately."

**Broken / stale link removed**
- `src/apps/tao_apps/triton_server_grpc.md:22` — Sentence pointed to `TRT-OSS/x86/README.md` and `TRT-OSS/Jetson/README.md` (paths don't exist in this repo; carryover from the standalone `deepstream_tao_apps` repo). The instruction was gated on "For TensorRT 8.6", but DS 9.0 ships TRT 10.13/10.14, so the guidance no longer applies — sentence removed entirely.

**Malformed GitHub URL fixed**
- `src/apps/tao_apps/deepstream_app_tao_configs/README.md:91` — `github.com/DeepStream/deepstream/-/tree/main/src/apps/tao_apps` (wrong org casing + GitLab-style `/-/tree/` infix that GitHub doesn't recognize) → `github.com/NVIDIA/DeepStream/tree/main/src/apps/tao_apps`

Bug: 6242551