### PR TITLE
docs: use repo-relative paths in READMEs and clarify UCX test usage

### DIFF
--- a/src/apps/sample_apps/deepstream-server/README
+++ b/src/apps/sample_apps/deepstream-server/README
@@ -717,12 +717,14 @@ Features supported with this application are:
   curl -XPOST 'http://localhost:9000/api/v1/analytics/reload-config' -d '{
   "stream":
     {
-      "config_file_path":"/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-server/config_nvdsanalytics.txt"
+      "config_file_path":"src/apps/sample_apps/deepstream-server/config_nvdsanalytics.txt"
     }
   }'
 
+Above path is relative to the repository root.
+
   Assumption: The sample deepstream-server-app uses "config_nvdsanalytics.txt"
-  config file available at "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-server/".
+  config file available at "src/apps/sample_apps/deepstream-server/ (relative to the repository root)".
   Hence, in the sample REST request same path and config file name is used.
   User should ensure to reload the same config file which has been used to run
   with the sample application.

--- a/src/apps/sample_apps/deepstream-test4/README
+++ b/src/apps/sample_apps/deepstream-test4/README
@@ -54,14 +54,14 @@ Dependencies
  Azure Iot:
  ----------
     Refer to the README files available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/azure_protocol_adaptor
+    src/utils/nvds_msgapi/azure_protocol_adaptor
     for detailed documentation on prerequisites and usages of Azure protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
  Kafka:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor
+    src/utils/nvds_msgapi/kafka_protocol_adaptor
     for detailed documentation on prerequisites and usages of kafka protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
@@ -70,17 +70,17 @@ Dependencies
     Install rabbitmq-c library
     --------------------------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/amqp_protocol_adaptor
+    src/utils/nvds_msgapi/amqp_protocol_adaptor
     for detailed documentation on prerequisites and usages of rabbitmq based
     amqp protocol adaptor with the message broker plugin for sending messages to cloud.
 
  Redis:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/redis_protocol_adaptor
+    src/utils/nvds_msgapi/redis_protocol_adaptor
     for detailed documentation on prerequisites and usages of redis protocol
     adaptor with the message broker plugin for sending messages to cloud.
-
+  Note: Above paths are relative to the repository root.
 SETUP:
   1.Use --proto-lib or -p command line option to set the path of adaptor library.
     Adaptor library can be found at /opt/nvidia/deepstream/deepstream/lib
@@ -119,7 +119,7 @@ SETUP:
   8.Use --cfg-file or -c command line option to set adaptor configuration file.
     This is optional if connection string has all relevent information.
 
-    For kafka: use /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor/cfg_kafka.txt as reference.
+    For kafka: use src/utils/nvds_msgapi/kafka_protocol_adaptor/cfg_kafka.txt as reference.
     This file is used to define the parition key field to be used while sending messages to the
     kafka broker. Refer Kafka Protocol Adaptor section in the DeepStream Plugin Manual for
     more details about using this config option. The partition-key setting within the cfg_kafka.txt
@@ -127,7 +127,7 @@ SETUP:
     "sensor.id" in case of Full message schema, and to "sensorId" in case of Minimal message schema
 
 
-    For Azure, use /opt/nvidia/deepstream/deepstream/sources/libs/azure_protocol_adaptor/device_client/cfg_azure.txt as reference.
+    For Azure, use src/utils/nvds_msgapi/azure_protocol_adaptor/device_client/cfg_azure.txt as reference.
     It has the following section:
         [message-broker]
         #connection_str = HostName=<my-hub>.azure-devices.net;DeviceId=<device_id>;SharedAccessKey=<my-policy-key>
@@ -143,7 +143,7 @@ SETUP:
 
         you can pass in full connection string with --conn-str option
 
-    For AMQP, use /opt/nvidia/deepstream/deepstream/sources/libs/amqp_protocol_adaptor/cfg_amqp.txt as reference.
+    For AMQP, use src/utils/nvds_msgapi/amqp_protocol_adaptor/cfg_amqp.txt as reference.
     It has the following default options:
         [message-broker]
         password = guest
@@ -162,7 +162,7 @@ SETUP:
 
         you can pass in full connection string with --conn-str option in format: "hostname;port;username;password"
 
-    For Redis, use /opt/nvidia/deepstream/deepstream/sources/libs/redis_protocol_adaptor/cfg_redis.txt as reference.
+    For Redis, use src/utils/nvds_msgapi/redis_protocol_adaptor/cfg_redis.txt as reference.
     It has the following default options:
         [message-broker]
         hostname=localhost
@@ -181,6 +181,7 @@ SETUP:
         you can pass in full connection string with --conn-str option in format: "hostname;port"
 
   NOTE:
+    - Above paths are relative to the repository root.
     - DO NOT delete the line [message-broker] in cfg file. Its the section identifier used for parsing
     - Share connection
       ----------------
@@ -320,7 +321,7 @@ Azure Iotedge runtime integration of deepstream-test4-app:
            "HostConfig": {
              "Runtime": "nvidia",
            },
-           "WorkingDir": "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test4",
+           "WorkingDir": "src/apps/sample_apps/deepstream-test4",
            "ENTRYPOINT":
            [
             "/opt/nvidia/deepstream/deepstream/bin/deepstream-test4-app",
@@ -334,7 +335,7 @@ Azure Iotedge runtime integration of deepstream-test4-app:
             "mytopic"
            ]
          }
-
+  Note: Above paths are relative to the repository root.
   - specify route options for the module:
 
     option 1) Default route where every message from every module is sent upstream

--- a/src/apps/sample_apps/deepstream-ucx-test/README
+++ b/src/apps/sample_apps/deepstream-ucx-test/README
@@ -142,7 +142,28 @@ serialized metadata via the Gst-NvDsMetaUtils library.
 4. Usage:
 ===============================================================================
 
-Compilation: To compile the sources, run make with "sudo" or root permission.
+This sample demonstrates the nvdsgst_ucx (Gst-NvDsUcx) plugin for transferring
+DeepStream buffers between a client and a server over an RDMA-capable network
+using UCX. Each test runs as a two-process pipeline on separate hosts with a
+ConnectX NIC; start the server first, then launch the client with matching IP,
+port, and stream parameters.
+
+Three test modes are supported via the -t option:
+
+  - Test 1 (-t 1): Basic video transmission. The server decodes a video source
+    and sends frames over UCX; the client receives, encodes, and writes the
+    output to a file.
+
+  - Test 2 (-t 2): Video with serialized metadata. The client runs inference
+    (nvinfer or nvinferserver), serializes object metadata with
+    Gst-NvDsMetaUtils, and sends video plus metadata; the server deserializes
+    the metadata, overlays it with nvdsosd, and writes the output file.
+
+  - Test 3 (-t 3): Audio with serialized metadata. The server extracts audio,
+    attaches serialized metadata from nvstreammux, and sends over UCX; the
+    client deserializes the metadata and writes the processed audio to a file.
+
+NOTE: To compile the sources, run make with "sudo" or root permission.
 
 Test 1:
    Server Setup:
@@ -168,8 +189,8 @@ Test 2:
    Pre-requisites:
    Navigate to the video_metadata_serialization directory and compile the
    library:
-   $ cd /opt/nvidia/deepstream/deepstream/sources/gst-plugins/\
-   gst-nvdsmetautils/video_metadata_serialization
+   $ cd src/gst-plugins/gst-nvdsmetautils/video_metadata_serialization
+   # Path is relative to the repository root.
    $ make
    $ sudo make install
 
@@ -210,8 +231,8 @@ Test 3:
    Pre-requisites:
    Navigate to the audio_metadata_serialization directory and compile the
    library:
-   $ cd /opt/nvidia/deepstream/deepstream/sources/gst-plugins/\
-   gst-nvdsmetautils/audio_metadata_serialization
+   $ cd src/gst-plugins/gst-nvdsmetautils/audio_metadata_serialization.
+   # Path is relative to the repository root.
    $ make
    $ sudo make install
 

--- a/src/gst-plugins/gst-dsexample-cuda/README
+++ b/src/gst-plugins/gst-dsexample-cuda/README
@@ -128,7 +128,7 @@ NOTE:
 4. This plugin contains additional sample to demonstrate CUDA memory usecases.
    It uses OpenCV CUDA to perform in-place operations on CUDA memory.
 5. To enable OpenCV in dsexample, set `WITH_OPENCV=1` in the plugin Makefile
-   (/opt/nvidia/deepstream/deepstream/sources/gst-plugins/gst-dsexample-cuda/Makefile)
+   (src/gst-plugins/gst-dsexample-cuda/Makefile, relative to the repository root)
    and follow compilation and installation instructions present in this README.
 6. The plugin demonstrates two in-place usecases:
    Swap Channels: Swaps the color channels leading to change in visual output.

--- a/src/gst-plugins/gst-dsexample/README
+++ b/src/gst-plugins/gst-dsexample/README
@@ -42,7 +42,7 @@ NOTE:
 of buffers. Refer to the Makefile for using optimized sample.
 3. OpenCV has been deprecated by default, so blur-objects will not work.
    To enable OpenCV in dsexample, set `WITH_OPENCV=1` in the plugin Makefile
-   (/opt/nvidia/deepstream/deepstream/sources/gst-plugins/gst-dsexample/Makefile)
+   (src/gst-plugins/gst-dsexample/Makefile, relative to the repository root)
    and follow compilation and installation instructions present in this README.
 
 --------------------------------------------------------------------------------

--- a/src/gst-plugins/gst-nvinfer/README
+++ b/src/gst-plugins/gst-nvinfer/README
@@ -38,6 +38,6 @@ NOTE:
 1. To compile the sources, run make with "sudo" or root permission.
 2. OpenCV has been deprecated by default, so GroupRectangles will not work.
    To use GroupRectangles, enable `WITH_OPENCV=1` in the Makefile of nvdsinfer
-   (/opt/nvidia/deepstream/deepstream/sources/libs/nvdsinfer/Makefile) and
+   (src/utils/nvdsinfer/Makefile, relative to the repository root) and
    follow compilation and installation instructions present in the README
-   (/opt/nvidia/deepstream/deepstream/sources/libs/nvdsinfer/README).
+   (src/utils/nvdsinfer/README, relative to the repository root).

--- a/src/service-maker/sources/apps/cpp/deepstream_3d_action_recognition_app/README
+++ b/src/service-maker/sources/apps/cpp/deepstream_3d_action_recognition_app/README
@@ -44,7 +44,7 @@ These Models support following classes :
   push;fall_floor;walk;run;ride_bike
 
 For More Info:
-    Check /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/README
+    Check src/apps/sample_apps/deepstream-3d-action-recognition/README (Relative to the repository root)
 
 
 ===============================================================================
@@ -80,7 +80,7 @@ input and the 2D model has NSHW shapes.
 For more custom 3D preprocessing details, see source files in /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/custom_sequence_preprocess.
 
 For More Info:
-    Check /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/README
+    Check src/apps/sample_apps/deepstream-3d-action-recognition/README (Relative to the repository root).
 
 ===============================================================================
 3. To compile:

--- a/src/service-maker/sources/apps/cpp/deepstream_sr_test_app/README
+++ b/src/service-maker/sources/apps/cpp/deepstream_sr_test_app/README
@@ -71,7 +71,8 @@ This sample demonstrates how to:
 1. Smart Record feature only works with live RTSP streams
 2. MSGCONV_CONFIG_FILE is required only when running with "--recording kafka"
 3. A sample MSGCONV_CONFIG_FILE is available at:
-   "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+   "src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+   Above path is relative to the repository root.
 4. The smart record feature allows for:
    - Event-based recording
    - Configurable recording duration
@@ -160,5 +161,6 @@ Follow these steps to use the smart record feature with Kafka:
 **Notes:**
 - Update the UTC time according to your current time and date
 - Sensor ID mapping is configured using the file:
-  `/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
+  `src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
+  Above path is relative to the repository root.
 - Update the sensor ID accordingly based on your configuration

--- a/src/service-maker/sources/apps/cpp/deepstream_test4_app/README
+++ b/src/service-maker/sources/apps/cpp/deepstream_test4_app/README
@@ -37,14 +37,14 @@ Dependencies
  Azure Iot:
  ----------
     Refer to the README files available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/azure_protocol_adaptor
+    src/utils/nvds_msgapi/azure_protocol_adaptor
     for detailed documentation on prerequisites and usages of Azure protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
  Kafka:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor
+    src/utils/nvds_msgapi/kafka_protocol_adaptor
     for detailed documentation on prerequisites and usages of kafka protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
@@ -53,17 +53,18 @@ Dependencies
     Install rabbitmq-c library
     --------------------------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/amqp_protocol_adaptor
+    src/utils/nvds_msgapi/amqp_protocol_adaptor
     for detailed documentation on prerequisites and usages of rabbitmq based
     amqp protocol adaptor with the message broker plugin for sending messages to cloud.
 
  Redis:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/redis_protocol_adaptor
+    src/utils/nvds_msgapi/redis_protocol_adaptor
     for detailed documentation on prerequisites and usages of redis protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
+ Above paths are relative to the repository root.
 ===============================================================================
 2. Purpose:
 ===============================================================================

--- a/src/service-maker/sources/apps/cpp/deepstream_test5_app/README
+++ b/src/service-maker/sources/apps/cpp/deepstream_test5_app/README
@@ -72,39 +72,63 @@ PAYLOAD_DEEPSTREAM_PROTOBUF - Protobuf encoded message with multiple objects in 
 
 $ ./deepstream-test5-app -s source-lists -c config-files [-l label-file] [--perf-measurement-interval-sec] [--hide-stream-name]
 
+Run from the build directory (see section 3). Config paths below are relative to
+that directory. Use *_x86.yaml pipeline configs on x86_64 and *_tegra.yaml on aarch64.
+
 Use nvurisrcbin for static input:
 
-$ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b2.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/source_list_static.yaml
+x86:
+$ ./deepstream-test5-app -c ../test5_b2_x86.yaml -s ../source_list_static.yaml
+
+aarch64:
+$ ./deepstream-test5-app -c ../test5_b2_tegra.yaml -s ../source_list_static.yaml
 
 Use nvmultiurisrcbin for dynamic input:
 
-$ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b16_dynamic_source.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/source_list_dynamic.yaml
+x86:
+$ ./deepstream-test5-app -c ../test5_b16_dynamic_source_x86.yaml -s ../source_list_dynamic.yaml
 
-Use camerabin for V4L2/CSI camera source
-$ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b2.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/camera_list.yaml
+aarch64:
+$ ./deepstream-test5-app -c ../test5_b16_dynamic_source_tegra.yaml -s ../source_list_dynamic.yaml
+
+Use camerabin for V4L2/CSI camera source:
+
+x86:
+$ ./deepstream-test5-app -c ../test5_b2_x86.yaml -s ../camera_list.yaml
+
+aarch64:
+$ ./deepstream-test5-app -c ../test5_b2_tegra.yaml -s ../camera_list.yaml
 
 Multiple pipelines are supported with multiple pipeline config files and source lists separated by ','
 
-$ ./deepstream-test5-app -s ../source_list_dynamic.yaml,../source_list_static.yaml -c ../test5_b16_dynamic_source.yaml,../test5_b2.yaml
+x86:
+$ ./deepstream-test5-app -s ../source_list_dynamic.yaml,../source_list_static.yaml -c ../test5_b16_dynamic_source_x86.yaml,../test5_b2_x86.yaml
 
-Enable/Disable the element within the pipeline
+aarch64:
+$ ./deepstream-test5-app -s ../source_list_dynamic.yaml,../source_list_static.yaml -c ../test5_b16_dynamic_source_tegra.yaml,../test5_b2_tegra.yaml
 
-$ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b16_dynamic_source_with_enable_property.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/source_list_dynamic.yaml
+Enable/Disable the element within the pipeline:
+
+x86:
+$ ./deepstream-test5-app -c ../test5_b16_dynamic_source_with_enable_property_x86.yaml -s ../source_list_dynamic.yaml
+
+aarch64:
+$ ./deepstream-test5-app -c ../test5_b16_dynamic_source_with_enable_property_tegra.yaml -s ../source_list_dynamic.yaml
 
 ===============================================================================
 5. Option [-l] 
 ===============================================================================
   5.1 This is an optional argument used to set label file for primary inference engine.
-  $ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b16_dynamic_source.yaml -s source_list_dynamic.yaml -l labels.txt
+  $ ./deepstream-test5-app -c ../test5_b16_dynamic_source_x86.yaml -s ../source_list_dynamic.yaml -l labels.txt
 
 ===============================================================================
 6. Option [--perf-measurement-interval-sec][Default: 1]
 ===============================================================================
   6.1 This is an optional argument used to set the interval between perf logs.
-  $ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b16_dynamic_source.yaml -s source_list_dynamic.yaml --perf-measurement-interval-sec 5
+  $ ./deepstream-test5-app -c ../test5_b16_dynamic_source_x86.yaml -s ../source_list_dynamic.yaml --perf-measurement-interval-sec 5
 
 ===============================================================================
 7. Option [--hide-stream-name][Default: false]
 ===============================================================================
   7.1 This argument is used to hide stream name in the perf logs
-  $ ./deepstream-test5-app -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/cpp/deepstream_test5_app/test5_b16_dynamic_source.yaml -s source_list_dynamic.yaml --hide-stream-name
+  $ ./deepstream-test5-app -c ../test5_b16_dynamic_source_x86.yaml -s ../source_list_dynamic.yaml --hide-stream-name

--- a/src/service-maker/sources/apps/python/flow_api/deepstream_3d_action_recognition_app/README
+++ b/src/service-maker/sources/apps/python/flow_api/deepstream_3d_action_recognition_app/README
@@ -44,7 +44,7 @@ These Models support following classes :
   push;fall_floor;walk;run;ride_bike
 
 For More Info:
-    Check /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/README
+    Check src/apps/sample_apps/deepstream-3d-action-recognition/README (Relative to the repository root)
 
 ===============================================================================
 2. Purpose:

--- a/src/service-maker/sources/apps/python/flow_api/deepstream_sr_test_app/README
+++ b/src/service-maker/sources/apps/python/flow_api/deepstream_sr_test_app/README
@@ -32,8 +32,8 @@ The application uses the following configuration files (default paths):
 
 ```
 KAFKA_PROTO_LIB_PATH = "/opt/nvidia/deepstream/deepstream/lib/libnvds_kafka_proto.so"
-KAFKA_CONFIG_FILE = "/opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor/cfg_kafka.txt"
-MSGCONV_CONFIG_FILE = "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+KAFKA_CONFIG_FILE = "src/utils/nvds_msgapi/kafka_protocol_adaptor/cfg_kafka.txt"
+MSGCONV_CONFIG_FILE = "src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
 CONFIG_FILE_PATH = "/opt/nvidia/deepstream/deepstream/samples/configs/deepstream-app/config_infer_primary.yml"
 ```
 
@@ -84,7 +84,7 @@ Run the application in one of the following modes:
 1. Smart Record feature only works with live RTSP streams.
 2. `MSGCONV_CONFIG_FILE` is required only when running with `-r cloud`.
 3. A sample MSGCONV_CONFIG_FILE is available at:
-   "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+   "src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
 4. The smart record feature allows for:
    - Event-based recording
    - Configurable recording duration
@@ -146,7 +146,7 @@ Follow these steps to use the smart record feature with Kafka:
 **Notes:**
 - Update the UTC time according to your current time and date
 - Sensor ID mapping is configured using the file:
-  `/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
+  `src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
 - Update the sensor ID accordingly based on your configuration
 
 ===============================================================================

--- a/src/service-maker/sources/apps/python/flow_api/deepstream_test5_app/README
+++ b/src/service-maker/sources/apps/python/flow_api/deepstream_test5_app/README
@@ -71,15 +71,17 @@ SGIE2_UNIQUE_ID = 6    # Unique identifier for make/model classification
 Kafka Protocol Configuration:
 ```
 PROTO_LIB_PATH = "/opt/nvidia/deepstream/deepstream/lib/libnvds_kafka_proto.so"
-PROTO_CONFIG_FILE = "/opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor/cfg_kafka.txt"
+PROTO_CONFIG_FILE = "src/utils/nvds_msgapi/kafka_protocol_adaptor/cfg_kafka.txt"
 ```
+Above path is relative to the repository root.
 
 Message Broker Configuration:
 ```
-MSGCONV_CONFIG_FILE = "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+MSGCONV_CONFIG_FILE = "src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
 MSGBROKER_CONN_STR = "localhost;9092"  # Kafka broker connection string
 MGSBROKER_TOPIC = "test5app"           # Kafka topic for message publishing
 ```
+Above path is relative to the repository root.
 
 Smart Recording Configuration:
 ```

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_3d_action_recognition_app/README
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_3d_action_recognition_app/README
@@ -44,7 +44,7 @@ These Models support following classes :
   push;fall_floor;walk;run;ride_bike
 
 For More Info:
-    Check /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/README
+    Check src/apps/sample_apps/deepstream-3d-action-recognition/README (Relative to the repository root).
 
 
 ===============================================================================
@@ -77,10 +77,11 @@ input and the 2D model has NSHW shapes.
     W: width
     S: channels x depth, reshaped from [C, D]
 
-For more custom 3D preprocessing details, see source files in /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/custom_sequence_preprocess.
+For more custom 3D preprocessing details, see source files in src/apps/sample_apps/deepstream-3d-action-recognition/custom_sequence_preprocess.
 
 For More Info:
-    Check /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-3d-action-recognition/README
+    Check 
+    src/apps/sample_apps/deepstream-3d-action-recognition/README
 
 ===============================================================================
 3. Usage:

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_sr_test_app/README
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_sr_test_app/README
@@ -78,7 +78,7 @@ The smart recording feature is configured with the following parameters:
 
 The application uses Kafka for event-based recording control (when run with -r kafka):
 * Kafka protocol library: /opt/nvidia/deepstream/deepstream/lib/libnvds_kafka_proto.so
-* Kafka configuration: /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor/cfg_kafka.txt
+* Kafka configuration: src/utils/nvds_msgapi/kafka_protocol_adaptor/cfg_kafka.txt
 * Kafka connection: localhost;9092
 * Kafka topic: sr-test
 
@@ -89,7 +89,7 @@ The application uses Kafka for event-based recording control (when run with -r k
 1. Smart Record feature only works with live RTSP streams
 2. MSGCONV_CONFIG_FILE is required only when running with "-r kafka"
 3. A sample MSGCONV_CONFIG_FILE is available at:
-   "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+   "src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
 4. The smart record feature allows for:
    - Event-based recording through Kafka messaging
    - Configurable recording duration and cache
@@ -177,5 +177,5 @@ Notes:
 **Notes:**
 - Update the UTC time according to your current time and date
 - Sensor ID mapping is configured using the file:
-  `/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
+  `src/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt`
 - Update the sensor ID accordingly based on your configuration

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test4_app/README
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test4_app/README
@@ -30,14 +30,14 @@ Dependencies
  Azure Iot:
  ----------
     Refer to the README files available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/azure_protocol_adaptor
+    src/utils/nvds_msgapi/azure_protocol_adaptor
     for detailed documentation on prerequisites and usages of Azure protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
  Kafka:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor
+    src/utils/nvds_msgapi/kafka_protocol_adaptor
     for detailed documentation on prerequisites and usages of kafka protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
@@ -46,17 +46,18 @@ Dependencies
     Install rabbitmq-c library
     --------------------------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/amqp_protocol_adaptor
+    src/utils/nvds_msgapi/amqp_protocol_adaptor
     for detailed documentation on prerequisites and usages of rabbitmq based
     amqp protocol adaptor with the message broker plugin for sending messages to cloud.
 
  Redis:
  ------
     Refer to the README file available under
-    /opt/nvidia/deepstream/deepstream/sources/libs/redis_protocol_adaptor
+    src/utils/nvds_msgapi/redis_protocol_adaptor
     for detailed documentation on prerequisites and usages of redis protocol
     adaptor with the message broker plugin for sending messages to cloud.
 
+ Above paths are relative to the repository root.
 ===============================================================================
 2. Purpose:
 ===============================================================================

--- a/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/README
+++ b/src/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/README
@@ -59,40 +59,63 @@ PAYLOAD_DEEPSTREAM_PROTOBUF - Protobuf encoded message with multiple objects in 
 
 $ python3 deepstream_test5.py -s source-lists -c config-files [-l label-file] [--perf-measurement-interval-sec] [--hide-stream-name]
 
+Run from this app directory. Config paths below are relative to that directory.
+Use *_x86.yaml pipeline configs on x86_64 and *_tegra.yaml on aarch64.
+
 Use nvurisrcbin for static input:
 
-$ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b2.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_static.yaml
+x86:
+$ python3 deepstream_test5.py -c test5_b2_x86.yaml -s source_list_static.yaml
+
+aarch64:
+$ python3 deepstream_test5.py -c test5_b2_tegra.yaml -s source_list_static.yaml
 
 Use nvmultiurisrcbin for dynamic input:
 
-$ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_dynamic.yaml
+x86:
+$ python3 deepstream_test5.py -c test5_b16_dynamic_source_x86.yaml -s source_list_dynamic.yaml
+
+aarch64:
+$ python3 deepstream_test5.py -c test5_b16_dynamic_source_tegra.yaml -s source_list_dynamic.yaml
 
 Use camerabin for V4L2/CSI camera source:
 
-$ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b2.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/camera_list.yaml
+x86:
+$ python3 deepstream_test5.py -c test5_b2_x86.yaml -s camera_list.yaml
+
+aarch64:
+$ python3 deepstream_test5.py -c test5_b2_tegra.yaml -s camera_list.yaml
 
 Multiple pipelines are supported with multiple pipeline config files and source lists separated by ' ':
 
-$ python3 deepstream_test5.py -s source_list_dynamic.yaml source_list_static.yaml -c test5_b16_dynamic_source.yaml test5_b2.yaml
+x86:
+$ python3 deepstream_test5.py -s source_list_dynamic.yaml source_list_static.yaml -c test5_b16_dynamic_source_x86.yaml test5_b2_x86.yaml
 
-Enable/Disable the element within the pipeline
+aarch64:
+$ python3 deepstream_test5.py -s source_list_dynamic.yaml source_list_static.yaml -c test5_b16_dynamic_source_tegra.yaml test5_b2_tegra.yaml
 
-$ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source_with_enable_property.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_dynamic.yaml
+Enable/Disable the element within the pipeline:
+
+x86:
+$ python3 deepstream_test5.py -c test5_b16_dynamic_source_with_enable_property_x86.yaml -s source_list_dynamic.yaml
+
+aarch64:
+$ python3 deepstream_test5.py -c test5_b16_dynamic_source_with_enable_property_tegra.yaml -s source_list_dynamic.yaml
 
 ===============================================================================
 4. Option [-l]
 ===============================================================================
   4.1 This is an optional argument used to set label file for primary inference engine.
-  $ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_dynamic.yaml -l labels.txt
+  $ python3 deepstream_test5.py -c test5_b16_dynamic_source_x86.yaml -s source_list_dynamic.yaml -l labels.txt
 
 ===============================================================================
 5. Option [--perf-measurement-interval-sec][Default: 1]
 ===============================================================================
   5.1 This is an optional argument used to set the interval between perf logs.
-  $ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_dynamic.yaml --perf-measurement-interval-sec 5
+  $ python3 deepstream_test5.py -c test5_b16_dynamic_source_x86.yaml -s source_list_dynamic.yaml --perf-measurement-interval-sec 5
 
 ===============================================================================
 6. Option [--hide-stream-name][Default: false]
 ===============================================================================
   6.1 This argument is used to hide stream name in the perf logs
-  $ python3 deepstream_test5.py -c /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/test5_b16_dynamic_source.yaml -s /opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test5_app/source_list_dynamic.yaml --hide-stream-name
+  $ python3 deepstream_test5.py -c test5_b16_dynamic_source_x86.yaml -s source_list_dynamic.yaml --hide-stream-name

--- a/src/utils/nvds_msgapi/kafka_protocol_adaptor/README
+++ b/src/utils/nvds_msgapi/kafka_protocol_adaptor/README
@@ -159,12 +159,13 @@ example:
 
 Before running the sample applications, enable logs by running the logger setup script:
 For x86,
- chmod u+x ~/deepstream_x86_public/sources/tools/nvds_logger/setup_nvds_logger.sh
- sudo ~/deepstream_x86_public/sources/tools/nvds_logger/setup_nvds_logger.sh
+ chmod u+x src/utils/nvds_logger/setup_nvds_logger.sh
+ sudo src/utils/nvds_logger/setup_nvds_logger.sh
 On Jetson,
- chmod u+x ~/deepstream_sdk_on_jetson/sources/tools/nvds_logger/setup_nvds_logger.sh
- sudo ~/deepstream_sdk_on_jetson/sources/tools/nvds_logger/setup_nvds_logger.sh
+ chmod u+x src/utils/nvds_logger/setup_nvds_logger.sh
+ sudo src/utils/nvds_logger/setup_nvds_logger.sh
 
+Above paths are relative to the repository root.
 Note that for complete set of logs, set the logger level to 7 (DEBUG), as described in the logger README.
 
 To run test program:

--- a/src/utils/nvds_msgapi/mqtt_protocol_adaptor/README
+++ b/src/utils/nvds_msgapi/mqtt_protocol_adaptor/README
@@ -147,11 +147,13 @@ Setup and enable logging:
 -------------------------
 Before running the sample applications, enable logs by running the logger setup script:
 For x86,
- chmod u+x /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
- sudo /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
+ chmod u+x src/utils/nvds_logger/setup_nvds_logger.sh
+ sudo src/utils/nvds_logger/setup_nvds_logger.sh
 On Jetson,
- chmod u+x /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
- sudo /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
+ chmod u+x src/utils/nvds_logger/setup_nvds_logger.sh
+ sudo src/utils/nvds_logger/setup_nvds_logger.sh
+
+Above paths are relative to the repository root.
 
 Building the adaptor
 ---------------------
@@ -173,13 +175,14 @@ In another terminal, you can also publish messages using the mosquitto pub clien
 Special case in gst-nvmsgbroker plugin and nvmsgbroker lib
 ----------------------------------------------------------
 The library name "libnvds_mqtt_proto.so" as set in the Makefile for mqtt protocol adaptor is hard-coded for a logic check in the gst-nvmsgbroker plugin
-See /opt/nvidia/deepstream/deepstream/sources/gst-plugins/gst-nvmsgbroker/gstnvmsgbroker.cpp. If the library name is changed, be sure to update accordingly in the
+See src/gst-plugins/gst-nvmsgbroker/gstnvmsgbroker.cpp. If the library name is changed, be sure to update accordingly in the
 plugin and re-compile and install.
 
 The protocol name "MQTT" as defined for NVDS_MSGAPI_PROTOCOL in nvds_mqtt_proto.cpp is hard-coded for a logic check in the nvmsgbroker lib.
-See /opt/nvidia/deepstream/deepstream/sources/libs/nvmsgbroker/nvmsgbroker.cpp. If the protocol name is changed, be sure to update accordingly in the lib and
+See src/utils/nvmsgbroker/nvmsgbroker.cpp. If the protocol name is changed, be sure to update accordingly in the lib and
 re-compile and install.
 
+Above paths are relative to the repository root.
 Limitations:
 ------------
 Synchronous send through `nvds_msgapi_send()` is not currently supported.

--- a/src/utils/nvds_msgapi/redis_protocol_adaptor/README
+++ b/src/utils/nvds_msgapi/redis_protocol_adaptor/README
@@ -139,9 +139,10 @@ example:
 
 Before running the sample applications, enable logs by running the logger setup script:
 --------------------------------------------------------------------------------------
- chmod u+x /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
- sudo /opt/nvidia/deepstream/deepstream/sources/tools/nvds_logger/setup_nvds_logger.sh
+ chmod u+x src/utils/nvds_logger/setup_nvds_logger.sh
+ sudo src/utils/nvds_logger/setup_nvds_logger.sh
 
+ Above paths are relative to the repository root.
  Note that for complete set of logs, set the logger level to 7 (DEBUG), as described in the logger README.
 
 To run test program:

--- a/src/utils/nvdsinferserver/README
+++ b/src/utils/nvdsinferserver/README
@@ -33,7 +33,7 @@ TRITON_GRPC_CLIENT ?= /opt/tritonclient
 HALF_PRECISION_LIB ?= /opt/half
 
 For installing the Triton gRPC client library and the protobuf compiler please
-check the steps in /opt/nvidia/deepstream/deepstream/sources/gst-plugins/gst-nvinferserver/README 
+check the steps in src/gst-plugins/gst-nvinferserver/README (relative to the repository root).
 
 Installing Half v2.1.0:
 mkdir /opt/half

--- a/src/utils/nvmsgbroker/README
+++ b/src/utils/nvmsgbroker/README
@@ -64,11 +64,12 @@ The following information is expected for each protocol:
     Redis: libnvds_redis_proto.so
 
   - Protocol-specific Connection string and/or configuration file
-    See README for each of the supported protocols:
-    Kafka: /opt/nvidia/deepstream/deepstream/sources/libs/kafka_protocol_adaptor
-    AMQP: /opt/nvidia/deepstream/deepstream/sources/libs/amqp_protocol_adaptor
-    Azure Device Client: /opt/nvidia/deepstream/deepstream/sources/libs/azure_protocol_adaptor
-    Redis: /opt/nvidia/deepstream/deepstream/sources/libs/redis_protocol_adaptor
+    See README for each of the supported protocols (below paths are relative to the repository root):
+    Kafka: src/utils/nvds_msgapi/kafka_protocol_adaptor
+    AMQP: src/utils/nvds_msgapi/amqp_protocol_adaptor
+    Azure Device Client: src/utils/nvds_msgapi/azure_protocol_adaptor
+    Redis: src/utils/nvds_msgapi/redis_protocol_adaptor
+
 
 Compiling and installing the plugin
 -----------------------------------


### PR DESCRIPTION
## docs: use repo-relative paths in READMEs and clarify UCX test usage

Replace hardcoded /opt/nvidia/deepstream install paths with src/ paths
relative to the repository root so docs work regardless of clone location.
Add a Usage summary to deepstream-ucx-test describing its three UCX test
modes. Update path references in sample app, plugin, service-maker and msgapi READMEs.