### PR TITLE
build: skip config-only reference_apps dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ src/apps/sample_apps/**/*.o
 src/apps/tao_apps/**/*.o
 src/apps/tao_apps/**/*.onnx
 src/apps/tao_apps/**/*.engine
+src/apps/reference_apps/**/*.o
+src/apps/reference_apps/**/*.so
+src/apps/reference_apps/**/*.a
 src/apps/reference_apps/**/*.onnx
 src/apps/reference_apps/**/*.engine
 src/apps/sample_apps/deepstream-testsr/With_BBox_*.mp4

--- a/build/build.sh
+++ b/build/build.sh
@@ -179,7 +179,24 @@ run_as_root make -C src/apps/tao_apps $MK 2>/dev/null || FAILED_BUILDS+=("src/ap
 # Reference apps (no top-level Makefile — build each individually)
 RA_BIN_STAGE=/tmp/ds-reference-apps-bin
 mkdir -p "$RA_BIN_STAGE"
+# Directories that ship only configs/assets (no Makefile to build).
+REF_APPS_SKIP=(
+  "deepstream-masktracker"
+  "deepstream-tracker-3d-multi-view"
+  "deepstream-tracker-3d"
+  "deepstream-vllm-plugin"
+  "pyservicemaker_sample_apps"
+)
 for dir in src/apps/reference_apps/*/; do
+  app=$(basename "$dir")
+  skip=0
+  for s in "${REF_APPS_SKIP[@]}"; do
+    if [ "$app" = "$s" ]; then skip=1; break; fi
+  done
+  if [ "$skip" -eq 1 ]; then
+    echo "Skipping $app (config-only, no build required)"
+    continue
+  fi
   if make -C "$dir" $MK BIN_DIR="$RA_BIN_STAGE" 2>/dev/null; then
     for bin in "$RA_BIN_STAGE"/deepstream-*; do
       [ -f "$bin" ] && [ -x "$bin" ] && run_as_root cp -v "$bin" "$DS_BIN/" || true

--- a/scripts/install_opensource_deps.sh
+++ b/scripts/install_opensource_deps.sh
@@ -137,6 +137,7 @@ find "$BUILD_ROOT/prom-install/lib" -name "libprometheus-cpp-core.so*" -exec cp 
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- azure-iot-sdk-c v1.11.0 ---"
+apt-get install uuid-dev
 AZURE_DIR=$BUILD_ROOT/azure-iot-sdk-c
 git clone https://github.com/Azure/azure-iot-sdk-c.git "$AZURE_DIR"
 git -C "$AZURE_DIR" checkout tags/1.11.0

--- a/src/apps/reference_apps/deepstream-bodypose-3d/README.md
+++ b/src/apps/reference_apps/deepstream-bodypose-3d/README.md
@@ -7,7 +7,7 @@ This application is built for [KAMA: 3D Keypoint Aware Body Mesh Articulation](h
 ![sample pose output](./sources/.screenshot.png)
 ## Prerequisites:
 DeepStream SDK 9.0 installed which is available at  http://developer.nvidia.com/deepstream-sdk
-Please follow instructions in the `/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-app/README` on how
+Please follow instructions in the `src/apps/sample_apps/deepstream-app/README` on how
 to install the prequisites for building Deepstream SDK apps.
 
 The pretrained TAO models [PeopleNet](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet) and [BodyPose3DNet](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/bodypose3dnet) from NGC.

--- a/src/apps/reference_apps/deepstream-custom-tile-config/README.md
+++ b/src/apps/reference_apps/deepstream-custom-tile-config/README.md
@@ -29,7 +29,7 @@ Run the sample with four video files and dislay on the screen
 ./deepstream-custom-tile-config -i file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_720p.mp4 \
                                    file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_720p.mp4 \
                                    file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_720p.mp4 \
-                                   file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_720p.mp4 \
+                                   file:///opt/nvidia/deepstream/deepstream/samples/streams/sample_720p.mp4
 ```
 
 ## Known Issue

--- a/src/apps/reference_apps/deepstream-ipc-test-sr/README.md
+++ b/src/apps/reference_apps/deepstream-ipc-test-sr/README.md
@@ -6,7 +6,7 @@ The client pipeline looks like "......-> nvstreammux -> pgie ->nvvideoconvert ->
 
 ## Prerequisites
 
-Please follow instructions in the /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-app/README on how
+Please follow instructions in the src/apps/sample_apps/deepstream-app/README on how
 to install the prerequisites for the Deepstream SDK, the DeepStream SDK itself, and the apps.
 
 You must have the following development packages installed

--- a/src/apps/reference_apps/deepstream-masktracker/README.md
+++ b/src/apps/reference_apps/deepstream-masktracker/README.md
@@ -14,8 +14,8 @@ Users need to install Ubuntu 24.04 and NVIDIA driver 570.133.20 on x86 with dGPU
 2. Git clone current repository to the host machine, and enter MaskTracker directory inside the repository. The directory `sam2-onnx-tensorrt` in tools folder will be used to convert SAM2 models for TensorRT inference later.
     ```bash
     $ git clone https://github.com/NVIDIA/DeepStream.git
-    $ sudo cp -r DeepStream/tools/sam2-onnx-tensorrt /opt/nvidia/deepstream/deepstream/sources/tracker_ReID/
-    $ cd DeepStream/src/apps/reference_apps/deepstream-masktracker
+    $ sudo cp -r tools/sam2-onnx-tensorrt /opt/nvidia/deepstream/deepstream/sources/tracker_ReID/
+    $ cd src/apps/reference_apps/deepstream-masktracker
     ```
 
 3. Download NVIDIA pretrained `PeopleNet` for detection from [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet/files?version=deployable_quantized_onnx_v2.6.3)(e.g., PeopleNet v2.6.3 in the example below).

--- a/src/apps/reference_apps/pyservicemaker_sample_apps/README.md
+++ b/src/apps/reference_apps/pyservicemaker_sample_apps/README.md
@@ -1,7 +1,7 @@
 ## Introduction
 The apps in this directory are additional samples demonstrating usage of the Python API for DeepStream Service Maker, either by flow API or by pipeline API. See the [Python Service Maker documentation](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_service_maker_python.html) for details.
 
-Other sample reference apps for pyservicemaker can be found at `/opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/`. Pysm sample apps using TAO pre-trained models can be found in the [deepstream_tao_apps](../../tao_apps/pysm-apps) repo.
+Other sample reference apps for pyservicemaker can be found at `service-maker/sources/apps/python/`. Pysm sample apps using TAO pre-trained models can be found in the [deepstream_tao_apps](../../tao_apps/pysm-apps) repo.
 
 ## Prerequisites
 * torchvision

--- a/src/apps/reference_apps/pyservicemaker_sample_apps/pipeline_api/deepstream_nvdsanalytics_test_app/README.md
+++ b/src/apps/reference_apps/pyservicemaker_sample_apps/pipeline_api/deepstream_nvdsanalytics_test_app/README.md
@@ -2,7 +2,7 @@
 
 This document describes the sample deepstream_nvdsanalytics_test application.
 
-This sample builds on top of the service-maker deepstream_test1 sample at at `/opt/nvidia/deepstream/deepstream/service-maker/sources/apps/python/pipeline_api/deepstream_test1_app` to demonstrate how to:
+This sample builds on top of the service-maker deepstream_test1 sample at at `service-maker/sources/apps/python/pipeline_api/deepstream_test1_app` to demonstrate how to:
 
 * Use multiple sources in the pipeline.
 * Use a uridecodebin so that any type of input (e.g. RTSP/File), any GStreamer

--- a/src/apps/tao_apps/apps/tao_others/deepstream-pose-classification/README.md
+++ b/src/apps/tao_apps/apps/tao_others/deepstream-pose-classification/README.md
@@ -6,7 +6,7 @@ The project contains pose classification application built using  Deepstream SDK
 ## Prerequisites:
 DeepStream SDK not less than 6.2 installed which is available at  http://developer.nvidia.com/deepstream-sdk
 
-Please follow instructions in the `/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-app/README` on how to install the prequisites for building Deepstream SDK apps.
+Please follow instructions in the `src/apps/sample_apps/deepstream-app/README` on how to install the prequisites for building Deepstream SDK apps.
 
 ## Installation
 1. Install libeigen3-dev

--- a/src/apps/tao_apps/pysm-apps/common/utils.py
+++ b/src/apps/tao_apps/pysm-apps/common/utils.py
@@ -156,7 +156,10 @@ class Config:
                         return self._config[sgie_key].get("bitrate")  or 2000000
                     case _ if "msg_conv_config" in name:
                         return self._config[sgie_key].get("msg-conv-config")  or \
-                        "/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt"
+                        os.path.abspath(os.path.join(
+                            os.path.dirname(__file__),
+                            "../../../sample_apps/deepstream-test5/configs/dstest5_msgconv_sample_config.txt",
+                        ))
                     case _ if "msg_broker_proto_lib" in name:
                         return self._config[sgie_key].get("msg-broker-proto-lib")  or \
                         "/opt/nvidia/deepstream/deepstream/lib/libnvds_kafka_proto.so"


### PR DESCRIPTION
Fix pysm-apps default msgconv config path and minor README/script tweaks.