### PR TITLE
ci: add SonarQube scan config for the mono-repo

### DIFF
--- a/.ngci/Jenkinsfile
+++ b/.ngci/Jenkinsfile
@@ -1,0 +1,34 @@
+pipeline {
+    agent { label 'vss-x86' }
+
+    environment {
+        SCANNER_HOME = tool 'DeepStream_SonarScanner'
+    }
+
+    stages {
+        stage('Checkout main') {
+            steps {
+                git branch: 'main',
+                    url: 'https://github.com/NVIDIA/DeepStream.git'
+            }
+        }
+
+        stage('SonarQube Analysis') {
+            steps {
+                withSonarQubeEnv('DeepStream_SonarQube') {
+                    sh """
+                        ${SCANNER_HOME}/bin/sonar-scanner
+                    """
+                }
+            }
+        }
+
+        stage('Quality Gate') {
+            steps {
+                timeout(time: 1, unit: 'HOURS') {
+                    waitForQualityGate abortPipeline: false
+                }
+            }
+        }
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=TEGRASW_Deepstream_Deepstream_Deepstream
+sonar.projectName=Deepstream Monorepo
+sonar.branch.name=main
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+sonar.exclusions=**/3rdparty/**,**/build/**,**/tests/**,**/unit-tests/**,**/*test_harness*,includes/**,tools/**,scripts/**,skills/**,example_prompts/**,.claude/**,.github/**,**/*.md,THIRD_PARTY_LICENSES.txt


### PR DESCRIPTION
## What
Adds the SonarQube analysis configuration so the Blossom CI scan can run against this repo:

- `.ngci/Jenkinsfile` — Blossom pipeline that runs `sonar-scanner` inside `withSonarQubeEnv` and waits on the quality gate.
- `sonar-project.properties` — project key `TEGRASW_Deepstream_Deepstream_Deepstream` ("Deepstream Monorepo"), sources/encoding, and exclusions for 3rdparty/build/test/tooling paths.

## Why
The scanner reads `sonar-project.properties` from the checked-out tree and the Blossom job runs `.ngci/Jenkinsfile`; both must be on the remote for analysis to execute. No secrets are included (token/host are injected by the Jenkins `withSonarQubeEnv` binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)