### PR TITLE
ci: skip Git LFS smudge in Sonar checkout (fix checkout failure)

### DIFF
--- a/.ngci/Jenkinsfile
+++ b/.ngci/Jenkinsfile
@@ -1,15 +1,26 @@
 pipeline {
     agent { label 'vss-x86' }
 
+    options {
+        // The default declarative checkout pulls Git LFS objects via a separate
+        // `ssh git@github.com` batch request that does NOT inherit Jenkins' SSH
+        // credential, so it fails with "Permission denied (publickey)" and aborts
+        // the checkout. Skip the implicit checkout and re-run it below with LFS
+        // smudge disabled -- a Sonar scan analyzes source, not the LFS media blobs.
+        skipDefaultCheckout(true)
+    }
+
     environment {
         SCANNER_HOME = tool 'DeepStream_SonarScanner'
+        GIT_LFS_SKIP_SMUDGE = '1'
     }
 
     stages {
         stage('Checkout main') {
             steps {
-                git branch: 'main',
-                    url: 'https://github.com/NVIDIA/DeepStream.git'
+                // Reuse the job's configured SCM (correct SSH credential + branch);
+                // GIT_LFS_SKIP_SMUDGE above keeps the checkout from fetching LFS objects.
+                checkout scm
             }
         }
 


### PR DESCRIPTION
## Problem
The Blossom Sonar job fails at **git checkout**, not at the scan. The Git LFS smudge step errors out:

```
Downloading src/apps/reference_apps/deepstream-bodypose-3d/streams/bodypose.mp4 (3.9 MB)
Error downloading object: ... batch request: git@github.com: Permission denied (publickey).
error: external filter 'git-lfs filter-process' failed
fatal: ... smudge filter lfs failed
```

The main `git fetch` authenticates fine via Jenkins' `GIT_SSH` credential wrapper, but `git-lfs` resolves objects through its **own** `ssh git@github.com` batch request that does **not** inherit that credential — so it gets `Permission denied (publickey)` and aborts the whole checkout.

## Fix
A Sonar scan analyzes source, not the LFS media blobs, so skip LFS during checkout:
- `options { skipDefaultCheckout(true) }` — avoid the implicit declarative checkout that performs the failing smudge.
- `environment { GIT_LFS_SKIP_SMUDGE = '1' }` — make the checkout leave LFS pointer files instead of downloading.
- `checkout scm` in the stage — reuse the job's already-working SCM credential (no hardcoded credentialsId), now with smudge disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)