### PR TITLE
ci: sshagent-wrap Sonar checkout so git-lfs authenticates

### DIFF
--- a/.ngci/Jenkinsfile
+++ b/.ngci/Jenkinsfile
@@ -2,25 +2,27 @@ pipeline {
     agent { label 'vss-x86' }
 
     options {
-        // The default declarative checkout pulls Git LFS objects via a separate
-        // `ssh git@github.com` batch request that does NOT inherit Jenkins' SSH
-        // credential, so it fails with "Permission denied (publickey)" and aborts
-        // the checkout. Skip the implicit checkout and re-run it below with LFS
-        // smudge disabled -- a Sonar scan analyzes source, not the LFS media blobs.
+        // Skip the implicit declarative checkout so the checkout below (which we
+        // wrap in sshagent) is the only one that runs. The implicit checkout cannot
+        // be wrapped, and git-lfs there fails to authenticate (see Checkout stage).
         skipDefaultCheckout(true)
     }
 
     environment {
         SCANNER_HOME = tool 'DeepStream_SonarScanner'
-        GIT_LFS_SKIP_SMUDGE = '1'
     }
 
     stages {
         stage('Checkout main') {
             steps {
-                // Reuse the job's configured SCM (correct SSH credential + branch);
-                // GIT_LFS_SKIP_SMUDGE above keeps the checkout from fetching LFS objects.
-                checkout scm
+                // git-lfs resolves LFS objects through its own `ssh git@github.com`
+                // batch request, which does NOT inherit the git plugin's GIT_SSH
+                // credential and fails with "Permission denied (publickey)", aborting
+                // the checkout. sshagent loads the job's SSH key into the ssh-agent so
+                // that git-lfs's ssh call authenticates and the LFS smudge succeeds.
+                sshagent(credentials: ['ankitat']) {
+                    checkout scm
+                }
             }
         }
 


### PR DESCRIPTION
## Problem
Follow-up to #52. The Sonar checkout still failed at the Git LFS smudge step:

```
batch request: git@github.com: Permission denied (publickey).
error: external filter 'git-lfs filter-process' failed
fatal: ... smudge filter lfs failed
```

`skipDefaultCheckout(true)` correctly took effect (the pipeline reached our `Checkout main` stage), but the `GIT_LFS_SKIP_SMUDGE=1` env var **did not reach** the checkout: the git-client plugin runs `git` with its own environment, so pipeline-level `environment{}` vars aren't exported to that subprocess. LFS smudge therefore still ran, and `git-lfs` resolves objects through its **own** `ssh git@github.com` batch request that doesn't inherit the plugin's `GIT_SSH` credential.

## Fix
Wrap `checkout scm` in `sshagent(credentials: ['ankitat'])` (the job's SSH key, "Sonarqube ID"). This loads the key into the ssh-agent that `git-lfs`'s own `ssh` call uses, so LFS authenticates and the checkout completes normally. `skipDefaultCheckout(true)` is kept so the unwrappable implicit checkout doesn't run. The non-functional `GIT_LFS_SKIP_SMUDGE` env line is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)