### PR TITLE
docs: remove non-existent python/ folder from service-maker layout

### DIFF
--- a/src/service-maker/README.md
+++ b/src/service-maker/README.md
@@ -11,7 +11,6 @@ Service Maker is a C++ and Python SDK that provides a high-level abstraction ove
 service-maker/
 ├── cmake/                        # CMake find-modules and toolchain files
 ├── includes/                     # Public C++ headers
-├── python/                       # Python bindings
 └── sources/
     ├── apps/
     │   ├── cpp/                  # C++ sample applications


### PR DESCRIPTION
The Layout tree in the Service Maker README listed a top-level python/ directory that does not exist. Python bindings live under sources/apps/python/, which is already documented elsewhere in the README.